### PR TITLE
docs(plan): decide PR-20c runner architecture with ADR

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -406,7 +406,8 @@ graph TD
 
 タスク:
 
-- [ ] Runner 実装方針を確定 (`tools/cli` 拡張 or `tools/agent-runner` 新設)
+- [x] Runner 実装方針を確定 (`tools/cli` 拡張 or `tools/agent-runner` 新設)
+  - ADR: `docs/adr/ADR-0001-llm-agent-runner.md` (`tools/agent-runner` 新設方針)
   - エントリポイント、設定ロード、責務分割を ADR 形式で文書化
 - [ ] Runner コア実装
   - `connect_token` 接続、`session_id` 再接続、`tools/list` / `tools/list_changed` 追従

--- a/docs/adr/ADR-0001-llm-agent-runner.md
+++ b/docs/adr/ADR-0001-llm-agent-runner.md
@@ -1,0 +1,97 @@
+# ADR-0001: LLM Agent Runner Architecture
+
+- Status: Accepted
+- Date: 2026-02-27
+- Related PLAN: PR-20c
+- Related SPEC: §3.1, §5.1, §5.2, §5.3, §7.1, §8.4, §9, §15.1
+
+## Context
+
+PR-20c requires a runtime that allows two LLM agents to join matches and play continuously with:
+
+- `connect_token` / `session_id` reconnect support
+- `tools/list` / `tools/list_changed` tracking
+- 1-turn-1-action normalization and guard validation
+- retry and backoff handling for unstable paths (`429`, disconnect, `DRAINING`)
+- structured logging with masking rules
+
+Current `tools/cli` is a lightweight manual connection client (`moltgame-client connect`) focused on interactive usage. Adding full runner orchestration into this package would mix two different responsibilities and increase coupling between simple operator tooling and automated agent runtime.
+
+## Decision
+
+Create a new workspace package: `tools/agent-runner`.
+
+Do not extend `tools/cli` for runner orchestration.
+
+### Why
+
+1. Separation of concerns
+
+- `tools/cli`: manual/debug client
+- `tools/agent-runner`: autonomous runtime for long-running matches
+
+2. Dependency isolation
+
+- Runner-specific dependencies (LLM adapters, validation helpers, retry policy utilities) can evolve independently from the CLI package.
+
+3. Testing clarity
+
+- Runner behavior requires dedicated unit/integration/e2e tests (adapter, reconnect loop, tool-guard path). Isolating package boundaries reduces accidental cross-impact.
+
+4. Deployment flexibility
+
+- Runner can be executed as a local process, CI utility, or future containerized worker without changing CLI behavior.
+
+## Entry Points and Package Boundaries
+
+`tools/agent-runner` will own:
+
+- `src/index.ts`: CLI entrypoint (`moltgame-runner`)
+- `src/config/*`: env/flag config loading and validation
+- `src/runtime/*`: connection/session/tool-state lifecycle
+- `src/adapter/*`: `LLMAdapter` abstraction and provider adapters
+- `src/guard/*`: allowed-tool and args-schema validation layer
+- `src/logging/*`: structured action trace with masking
+
+`tools/cli` remains unchanged as a low-level/manual connection tool.
+
+## Configuration Model
+
+Runner configuration is loaded with precedence:
+
+1. CLI flags
+2. environment variables
+3. defaults
+
+Minimum initial config set:
+
+- gateway endpoints (`GATEWAY_URL`, `GATEWAY_WS_URL`, `ENGINE_URL`)
+- auth source (`BENCH_AUTH_TOKEN` or equivalent runner auth token)
+- provider/model (`OPENAI_API_KEY`, `OPENAI_MODEL`, provider selector)
+- retry/backoff tuning (`RECONNECT_*`, `TOKEN_RETRY_*`)
+- execution controls (`MATCH_COUNT`, `MAX_STEPS`, `TIMEOUT_MS`)
+
+## Consequences
+
+Positive:
+
+- cleaner architecture for PR-20c scope expansion
+- safer evolution of automated runtime behavior
+- clearer onboarding for operator CLI vs autonomous runner
+
+Trade-off:
+
+- one additional package to maintain in workspace
+- some duplicated low-level WS utility code may appear before extraction
+
+Mitigation:
+
+- if duplication emerges, extract shared primitives into a dedicated package in a follow-up task
+
+## Follow-up Tasks (PR-20c)
+
+1. Runner core implementation in `tools/agent-runner`
+2. `LLMAdapter` (`MockLLMAdapter`, `OpenAIAdapter`)
+3. tool-call guard and retry policy
+4. observability + masking
+5. tests (unit/integration/e2e) and docs


### PR DESCRIPTION
## Purpose
Define and lock the implementation direction for PLAN PR-20c runner architecture before coding core runtime features.

## Changes
- Added ADR document:
  - `docs/adr/ADR-0001-llm-agent-runner.md`
  - Decision: create `tools/agent-runner` package and keep `tools/cli` as manual/debug client.
  - Included boundaries, config precedence, consequences, and follow-up steps.
- Updated `docs/PLAN.md`:
  - Marked PR-20c task `Runner 実装方針を確定` as completed.
  - Added ADR reference link under the task.

## Test Results
Executed locally:
- `pnpm format:check` ✅
- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm test:unit` ✅
- `pnpm test:integration` ✅
- `pnpm test:e2e` ✅
- `pnpm build` ✅

## Risk / Rollback
- Risk is low (documentation-only change, no runtime behavior changes).
- Rollback: revert this PR commit to restore previous PLAN/ADR state.

## References
- PLAN: PR-20c (Runner 実装方針)
- SPEC: §3.1, §5.1, §5.2, §5.3, §7.1, §8.4, §9, §15.1
