### PR TITLE
feat(kpi): gameplay KPI measurement foundation

### DIFF
--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -72,6 +72,7 @@ import {
 } from './spectator/latency-recorder.js';
 import { RedisMatchActionRateLimiter } from './websocket/match-action-rate-limiter.js';
 import { sendRestApiError } from './api-error.js';
+import { registerKpiRoutes } from './kpi/routes.js';
 
 class MockFirebaseVerifier implements FirebaseIdTokenVerifier {
   async verifyIdToken(_idToken: string): Promise<VerifiedFirebaseIdToken> {
@@ -1236,6 +1237,9 @@ export const createApp = async (options: AppOptions = {}) => {
 
   app.post('/v1/tokens', handleConnectTokenRequest);
   app.delete('/v1/tokens/:tokenId', handleConnectTokenRequest);
+
+  // KPI measurement routes (PR-18b)
+  registerKpiRoutes(app);
 
   app.post('/v1/auth/device', async (_request, reply) => {
     const result = await deviceAuthService.issueAuthorization();

--- a/apps/gateway/src/kpi/routes.ts
+++ b/apps/gateway/src/kpi/routes.ts
@@ -1,0 +1,154 @@
+/**
+ * KPI API routes — PR-18b
+ *
+ * GET /v1/kpi/summary?gameId=&days=7&ruleVersion=
+ *   Returns KpiSnapshot[] for the specified game over the given time window.
+ *   NOTE: Currently returns stub in-memory data.
+ *         Firestore integration (reading from the metrics collection) is
+ *         intentionally deferred to the Firestore pipeline PR.
+ *
+ * GET /v1/kpi/diff?gameId=&ruleVersionA=&ruleVersionB=
+ *   Returns a KpiDiff comparing two rule versions for a given game.
+ *   NOTE: Same stub approach — real data will come from Firestore.
+ */
+
+import type { FastifyInstance } from 'fastify';
+
+import { computeKpiDiff, type KpiSnapshot } from '@moltgames/domain';
+import {
+  KpiAggregator,
+  type MatchSummary,
+  type TurnEventSummary,
+} from '../services/kpi-aggregator.js';
+import { sendRestApiError } from '../api-error.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const getQueryStringValue = (value: unknown): string | null => {
+  if (typeof value === 'string' && value.length > 0) return value;
+  if (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    typeof value[0] === 'string' &&
+    value[0].length > 0
+  ) {
+    return value[0];
+  }
+  return null;
+};
+
+const parsePositiveDays = (raw: string | null): number | null => {
+  if (raw === null) return 7; // default
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isInteger(n) || n <= 0) return null;
+  return n;
+};
+
+// ---------------------------------------------------------------------------
+// Stub data generator
+// NOTE: Replace with Firestore reads once the metrics pipeline is in place.
+// ---------------------------------------------------------------------------
+
+const makeStubMatches = (count: number): MatchSummary[] =>
+  Array.from({ length: count }, (_, i) => ({
+    matchId: `stub-match-${i}`,
+    gameId: 'stub',
+    ruleVersion: '1.0.0',
+    queueType: 'ranked',
+    ratingBracket: '1400-1600',
+    winnerId: i % 3 !== 0 ? 'agent-a' : null,
+    finalScores: { 'agent-a': 50 + (i % 10), 'agent-b': 50 - (i % 10) },
+    durationMs: 90_000 + i * 1_000,
+    createdAt: new Date(Date.now() - i * 3_600_000).toISOString(),
+  }));
+
+const makeStubTurnEvents = (): TurnEventSummary[] => {
+  const actions = ['attack', 'defend', 'negotiate', 'flee'];
+  return Array.from({ length: 40 }, (_, i) => ({
+    matchId: `stub-match-${i % 10}`,
+    actionType: actions[i % actions.length] ?? 'attack',
+    scoreDiffBefore: i % 5,
+    scoreDiffAfter: (i % 5) + 1,
+  }));
+};
+
+const agg = new KpiAggregator();
+
+const buildStubSnapshot = (gameId: string, ruleVersion: string, days: number): KpiSnapshot => {
+  const matches = makeStubMatches(Math.max(10, days * 5));
+  const turnEvents = makeStubTurnEvents();
+
+  const now = new Date();
+  const from = new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
+  const period = `${from.toISOString().slice(0, 10)}/${now.toISOString().slice(0, 10)}`;
+
+  return agg.aggregate({
+    gameId,
+    ruleVersion,
+    queueType: 'ranked',
+    ratingBracket: 'all',
+    period,
+    matches,
+    turnEvents,
+    returnEvents: [],
+  });
+};
+
+// ---------------------------------------------------------------------------
+// Route registration
+// ---------------------------------------------------------------------------
+
+export const registerKpiRoutes = (app: FastifyInstance): void => {
+  // GET /v1/kpi/summary
+  app.get('/v1/kpi/summary', async (request, reply) => {
+    const query = request.query as Record<string, unknown>;
+
+    const gameId = getQueryStringValue(query.gameId);
+    if (gameId === null) {
+      return sendRestApiError(reply, 400, 'INVALID_REQUEST', 'gameId is required');
+    }
+
+    const daysRaw = getQueryStringValue(query.days);
+    const days = parsePositiveDays(daysRaw);
+    if (days === null) {
+      return sendRestApiError(reply, 400, 'INVALID_REQUEST', 'days must be a positive integer');
+    }
+
+    const ruleVersion = getQueryStringValue(query.ruleVersion) ?? 'latest';
+
+    // TODO(PR-18c): Replace stub with real Firestore reads from kpi_snapshots collection.
+    const snapshot = buildStubSnapshot(gameId, ruleVersion, days);
+
+    return reply.send({ status: 'ok', snapshots: [snapshot] });
+  });
+
+  // GET /v1/kpi/diff
+  app.get('/v1/kpi/diff', async (request, reply) => {
+    const query = request.query as Record<string, unknown>;
+
+    const gameId = getQueryStringValue(query.gameId);
+    if (gameId === null) {
+      return sendRestApiError(reply, 400, 'INVALID_REQUEST', 'gameId is required');
+    }
+
+    const ruleVersionA = getQueryStringValue(query.ruleVersionA);
+    if (ruleVersionA === null) {
+      return sendRestApiError(reply, 400, 'INVALID_REQUEST', 'ruleVersionA is required');
+    }
+
+    const ruleVersionB = getQueryStringValue(query.ruleVersionB);
+    if (ruleVersionB === null) {
+      return sendRestApiError(reply, 400, 'INVALID_REQUEST', 'ruleVersionB is required');
+    }
+
+    // TODO(PR-18c): Replace stub with real Firestore reads.
+    const snapshotA = buildStubSnapshot(gameId, ruleVersionA, 7);
+    const snapshotB = buildStubSnapshot(gameId, ruleVersionB, 7);
+
+    const diff = computeKpiDiff(snapshotA, snapshotB);
+
+    return reply.send({ status: 'ok', diff });
+  });
+};

--- a/apps/gateway/src/kpi/routes.ts
+++ b/apps/gateway/src/kpi/routes.ts
@@ -59,6 +59,7 @@ const makeStubMatches = (count: number): MatchSummary[] =>
     queueType: 'ranked',
     ratingBracket: '1400-1600',
     winnerId: i % 3 !== 0 ? 'agent-a' : null,
+    winnerSeat: i % 2 === 0 ? 'first' : 'second',
     finalScores: { 'agent-a': 50 + (i % 10), 'agent-b': 50 - (i % 10) },
     durationMs: 90_000 + i * 1_000,
     createdAt: new Date(Date.now() - i * 3_600_000).toISOString(),
@@ -69,6 +70,7 @@ const makeStubTurnEvents = (): TurnEventSummary[] => {
   return Array.from({ length: 40 }, (_, i) => ({
     matchId: `stub-match-${i % 10}`,
     actionType: actions[i % actions.length] ?? 'attack',
+    seat: i % 2 === 0 ? 'first' : 'second',
     scoreDiffBefore: i % 5,
     scoreDiffAfter: (i % 5) + 1,
   }));

--- a/apps/gateway/src/services/kpi-aggregator.ts
+++ b/apps/gateway/src/services/kpi-aggregator.ts
@@ -1,0 +1,220 @@
+import { computeKpiDiff, type KpiDiff, type KpiSnapshot } from '@moltgames/domain';
+
+// ---------------------------------------------------------------------------
+// Input types (pre-fetched from Firestore / Redis – no direct DB calls here)
+// ---------------------------------------------------------------------------
+
+export interface MatchSummary {
+  readonly matchId: string;
+  readonly gameId: string;
+  readonly ruleVersion: string;
+  readonly queueType: string;
+  readonly ratingBracket: string;
+  /** null means draw */
+  readonly winnerId: string | null;
+  /** agentId → numeric score */
+  readonly finalScores: Readonly<Record<string, number>>;
+  readonly durationMs: number;
+  readonly createdAt: string;
+}
+
+export interface TurnEventSummary {
+  readonly matchId: string;
+  readonly actionType: string;
+  readonly scoreDiffBefore: number;
+  readonly scoreDiffAfter: number;
+}
+
+export interface ReturnEvent {
+  readonly uid: string;
+  readonly returnedAt: string;
+  readonly previousMatchAt: string;
+}
+
+export interface AggregateParams {
+  readonly gameId: string;
+  readonly ruleVersion: string;
+  readonly queueType: string;
+  readonly ratingBracket: string;
+  /** ISO-8601 interval string, e.g. "2026-03-01/2026-03-08" */
+  readonly period: string;
+  readonly matches: readonly MatchSummary[];
+  readonly turnEvents: readonly TurnEventSummary[];
+  readonly returnEvents: readonly ReturnEvent[];
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers (pure functions)
+// ---------------------------------------------------------------------------
+
+/** Returns the maximum absolute score across all participants. */
+const maxScore = (scores: Readonly<Record<string, number>>): number => {
+  const values = Object.values(scores);
+  if (values.length === 0) return 0;
+  return Math.max(...values.map((v) => Math.abs(v)));
+};
+
+/** Returns the absolute score difference between the top two participants. */
+const scoreDiff = (scores: Readonly<Record<string, number>>): number => {
+  const sorted = Object.values(scores).sort((a, b) => b - a);
+  if (sorted.length < 2) return 0;
+  return Math.abs((sorted[0] ?? 0) - (sorted[1] ?? 0));
+};
+
+/**
+ * Wilson score 95 % confidence interval for a proportion.
+ * Falls back to [p, p] when n is 0.
+ */
+const wilsonCI = (count: number, n: number): readonly [number, number] => {
+  if (n === 0) return [0, 0];
+
+  const p = count / n;
+  const z = 1.96; // 95% confidence
+  const center = p + (z * z) / (2 * n);
+  const spread = z * Math.sqrt((p * (1 - p)) / n + (z * z) / (4 * n * n));
+  const denominator = 1 + (z * z) / n;
+
+  const lo = Math.max(0, (center - spread) / denominator);
+  const hi = Math.min(1, (center + spread) / denominator);
+
+  return [lo, hi];
+};
+
+/** Shannon entropy (log base 2) of a frequency map. */
+const shannonEntropy = (freqMap: Readonly<Record<string, number>>): number => {
+  const total = Object.values(freqMap).reduce((s, v) => s + v, 0);
+  if (total === 0) return 0;
+
+  return Object.values(freqMap).reduce((entropy, count) => {
+    if (count === 0) return entropy;
+    const p = count / total;
+    return entropy - p * Math.log2(p);
+  }, 0);
+};
+
+// ---------------------------------------------------------------------------
+// KpiAggregator
+// ---------------------------------------------------------------------------
+
+export class KpiAggregator {
+  /**
+   * Competitive Match Rate — fraction of matches decided by ≤10% score diff.
+   */
+  computeCMR(matches: readonly MatchSummary[]): number {
+    if (matches.length === 0) return 0;
+
+    const competitive = matches.filter((m) => {
+      const max = maxScore(m.finalScores);
+      if (max === 0) return false;
+      const diff = scoreDiff(m.finalScores);
+      return diff / max <= 0.1;
+    });
+
+    return competitive.length / matches.length;
+  }
+
+  /**
+   * Close Win Rate — fraction of matches where the winner won by ≤20% of max score.
+   */
+  computeCWR(matches: readonly MatchSummary[]): number {
+    if (matches.length === 0) return 0;
+
+    const closeWins = matches.filter((m) => {
+      if (m.winnerId === null) return false;
+      const max = maxScore(m.finalScores);
+      if (max === 0) return false;
+      const diff = scoreDiff(m.finalScores);
+      return diff / max <= 0.2;
+    });
+
+    return closeWins.length / matches.length;
+  }
+
+  /**
+   * Action Diversity Index — Shannon entropy (log₂) of action type distribution.
+   */
+  computeADI(turnEvents: readonly TurnEventSummary[]): number {
+    if (turnEvents.length === 0) return 0;
+
+    const freqMap: Record<string, number> = {};
+    for (const event of turnEvents) {
+      freqMap[event.actionType] = (freqMap[event.actionType] ?? 0) + 1;
+    }
+
+    return shannonEntropy(freqMap);
+  }
+
+  /**
+   * Return In 24h Rate — fraction of matches whose participants returned within 24 h.
+   * Uses pre-fetched ReturnEvent records; denominator is the number of matches.
+   */
+  computeRIR24(matches: readonly MatchSummary[], returnEvents: readonly ReturnEvent[]): number {
+    if (matches.length === 0) return 0;
+
+    const twentyFourHoursMs = 24 * 60 * 60 * 1000;
+
+    const qualifyingCount = returnEvents.filter((re) => {
+      const prevMs = new Date(re.previousMatchAt).getTime();
+      const retMs = new Date(re.returnedAt).getTime();
+      return retMs - prevMs <= twentyFourHoursMs;
+    }).length;
+
+    return qualifyingCount / matches.length;
+  }
+
+  /**
+   * Aggregate all KPI metrics into a single KpiSnapshot.
+   * This is the main entry point; all data must be passed in — no I/O here.
+   */
+  aggregate(params: AggregateParams): KpiSnapshot {
+    const { matches, turnEvents, returnEvents } = params;
+    const n = matches.length;
+
+    const cmr = this.computeCMR(matches);
+    const cwr = this.computeCWR(matches);
+    const adi = this.computeADI(turnEvents);
+    const rir24 = this.computeRIR24(matches, returnEvents);
+
+    // Count numerators for Wilson CI
+    const cmrCount = Math.round(cmr * n);
+    const cwrCount = Math.round(cwr * n);
+    const rir24Count = Math.round(rir24 * n);
+
+    const metrics: Record<string, number> = {
+      CMR: cmr,
+      CWR: cwr,
+      ADI: adi,
+      RIR24: rir24,
+    };
+
+    // ADI confidence: simple ±5% of value (entropy has no standard Wilson CI)
+    const adiLo = Math.max(0, adi * 0.95);
+    const adiHi = adi * 1.05;
+
+    const confidence: Record<string, readonly [number, number]> = {
+      CMR: wilsonCI(cmrCount, n),
+      CWR: wilsonCI(cwrCount, n),
+      ADI: [adiLo, adiHi],
+      RIR24: wilsonCI(rir24Count, n),
+    };
+
+    return {
+      gameId: params.gameId,
+      ruleVersion: params.ruleVersion,
+      queueType: params.queueType,
+      ratingBracket: params.ratingBracket,
+      period: params.period,
+      sampleSize: n,
+      metrics,
+      confidence,
+      computedAt: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Convenience wrapper: compute a KpiDiff between two pre-aggregated snapshots.
+   */
+  diff(a: KpiSnapshot, b: KpiSnapshot): KpiDiff {
+    return computeKpiDiff(a, b);
+  }
+}

--- a/apps/gateway/src/services/kpi-aggregator.ts
+++ b/apps/gateway/src/services/kpi-aggregator.ts
@@ -12,6 +12,7 @@ export interface MatchSummary {
   readonly ratingBracket: string;
   /** null means draw */
   readonly winnerId: string | null;
+  readonly winnerSeat: 'first' | 'second' | null;
   /** agentId → numeric score */
   readonly finalScores: Readonly<Record<string, number>>;
   readonly durationMs: number;
@@ -21,12 +22,14 @@ export interface MatchSummary {
 export interface TurnEventSummary {
   readonly matchId: string;
   readonly actionType: string;
+  readonly seat: 'first' | 'second';
   readonly scoreDiffBefore: number;
   readonly scoreDiffAfter: number;
 }
 
 export interface ReturnEvent {
   readonly uid: string;
+  readonly previousMatchId: string;
   readonly returnedAt: string;
   readonly previousMatchAt: string;
 }
@@ -92,6 +95,48 @@ const shannonEntropy = (freqMap: Readonly<Record<string, number>>): number => {
   }, 0);
 };
 
+/** Normalized Shannon entropy in the range [0, 1]. */
+const normalizedEntropy = (freqMap: Readonly<Record<string, number>>): number => {
+  const actionTypes = Object.keys(freqMap).length;
+  if (actionTypes <= 1) return 0;
+  return shannonEntropy(freqMap) / Math.log2(actionTypes);
+};
+
+const percentile = (sortedValues: readonly number[], fraction: number): number => {
+  if (sortedValues.length === 0) return 0;
+
+  const index = (sortedValues.length - 1) * fraction;
+  const lowerIndex = Math.floor(index);
+  const upperIndex = Math.ceil(index);
+  const lower = sortedValues[lowerIndex] ?? sortedValues[sortedValues.length - 1] ?? 0;
+  const upper = sortedValues[upperIndex] ?? lower;
+
+  if (lowerIndex === upperIndex) {
+    return lower;
+  }
+
+  const weight = index - lowerIndex;
+  return lower + (upper - lower) * weight;
+};
+
+const bootstrapCI = <T>(
+  items: readonly T[],
+  estimator: (sample: readonly T[]) => number,
+  iterations = 500,
+): readonly [number, number] => {
+  if (items.length === 0) return [0, 0];
+
+  const estimates = Array.from({ length: iterations }, () => {
+    const sample = Array.from(
+      { length: items.length },
+      () => items[Math.floor(Math.random() * items.length)]!,
+    );
+    return estimator(sample);
+  }).sort((a, b) => a - b);
+
+  return [percentile(estimates, 0.025), percentile(estimates, 0.975)];
+};
+
 // ---------------------------------------------------------------------------
 // KpiAggregator
 // ---------------------------------------------------------------------------
@@ -114,24 +159,35 @@ export class KpiAggregator {
   }
 
   /**
-   * Close Win Rate — fraction of matches where the winner won by ≤20% of max score.
+   * Comeback Win Rate — fraction of matches where the eventual winner was
+   * trailing at some point before winning.
    */
-  computeCWR(matches: readonly MatchSummary[]): number {
+  computeCWR(matches: readonly MatchSummary[], turnEvents: readonly TurnEventSummary[]): number {
     if (matches.length === 0) return 0;
 
-    const closeWins = matches.filter((m) => {
-      if (m.winnerId === null) return false;
-      const max = maxScore(m.finalScores);
-      if (max === 0) return false;
-      const diff = scoreDiff(m.finalScores);
-      return diff / max <= 0.2;
+    const eventsByMatch = new Map<string, TurnEventSummary[]>();
+    for (const event of turnEvents) {
+      const bucket = eventsByMatch.get(event.matchId) ?? [];
+      bucket.push(event);
+      eventsByMatch.set(event.matchId, bucket);
+    }
+
+    const comebackWins = matches.filter((match) => {
+      if (match.winnerId === null || match.winnerSeat === null) return false;
+
+      const events = eventsByMatch.get(match.matchId) ?? [];
+      return events.some((event) => {
+        const winnerPerspectiveScoreDiff =
+          event.seat === match.winnerSeat ? event.scoreDiffBefore : -event.scoreDiffBefore;
+        return winnerPerspectiveScoreDiff < 0;
+      });
     });
 
-    return closeWins.length / matches.length;
+    return comebackWins.length / matches.length;
   }
 
   /**
-   * Action Diversity Index — Shannon entropy (log₂) of action type distribution.
+   * Action Diversity Index — normalized Shannon entropy of action types.
    */
   computeADI(turnEvents: readonly TurnEventSummary[]): number {
     if (turnEvents.length === 0) return 0;
@@ -141,7 +197,7 @@ export class KpiAggregator {
       freqMap[event.actionType] = (freqMap[event.actionType] ?? 0) + 1;
     }
 
-    return shannonEntropy(freqMap);
+    return normalizedEntropy(freqMap);
   }
 
   /**
@@ -152,14 +208,26 @@ export class KpiAggregator {
     if (matches.length === 0) return 0;
 
     const twentyFourHoursMs = 24 * 60 * 60 * 1000;
+    const knownMatchIds = new Set(matches.map((match) => match.matchId));
 
-    const qualifyingCount = returnEvents.filter((re) => {
-      const prevMs = new Date(re.previousMatchAt).getTime();
-      const retMs = new Date(re.returnedAt).getTime();
-      return retMs - prevMs <= twentyFourHoursMs;
-    }).length;
+    const qualifyingMatchIds = new Set(
+      returnEvents.flatMap((re) => {
+        const prevMs = new Date(re.previousMatchAt).getTime();
+        const retMs = new Date(re.returnedAt).getTime();
+        const elapsedMs = retMs - prevMs;
+        if (
+          elapsedMs < 0 ||
+          elapsedMs > twentyFourHoursMs ||
+          !knownMatchIds.has(re.previousMatchId)
+        ) {
+          return [];
+        }
 
-    return qualifyingCount / matches.length;
+        return [re.previousMatchId];
+      }),
+    );
+
+    return qualifyingMatchIds.size / matches.length;
   }
 
   /**
@@ -171,7 +239,7 @@ export class KpiAggregator {
     const n = matches.length;
 
     const cmr = this.computeCMR(matches);
-    const cwr = this.computeCWR(matches);
+    const cwr = this.computeCWR(matches, turnEvents);
     const adi = this.computeADI(turnEvents);
     const rir24 = this.computeRIR24(matches, returnEvents);
 
@@ -187,14 +255,10 @@ export class KpiAggregator {
       RIR24: rir24,
     };
 
-    // ADI confidence: simple ±5% of value (entropy has no standard Wilson CI)
-    const adiLo = Math.max(0, adi * 0.95);
-    const adiHi = adi * 1.05;
-
     const confidence: Record<string, readonly [number, number]> = {
       CMR: wilsonCI(cmrCount, n),
       CWR: wilsonCI(cwrCount, n),
-      ADI: [adiLo, adiHi],
+      ADI: bootstrapCI(turnEvents, (sample) => this.computeADI(sample)),
       RIR24: wilsonCI(rir24Count, n),
     };
 

--- a/apps/gateway/test/unit/routes/kpi.test.ts
+++ b/apps/gateway/test/unit/routes/kpi.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+import { createApp } from '../../../src/app.js';
+import type { KpiSnapshot } from '@moltgames/domain';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const buildApp = async () => {
+  process.env.NODE_ENV = 'test';
+  return createApp();
+};
+
+// ---------------------------------------------------------------------------
+// GET /v1/kpi/summary
+// ---------------------------------------------------------------------------
+
+describe('GET /v1/kpi/summary', () => {
+  it('returns 200 with an array of KpiSnapshot objects', async () => {
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/kpi/summary?gameId=prompt-injection-arena&days=7',
+    });
+
+    expect(res.statusCode).toBe(200);
+
+    const body = res.json<{ status: string; snapshots: KpiSnapshot[] }>();
+    expect(body.status).toBe('ok');
+    expect(Array.isArray(body.snapshots)).toBe(true);
+
+    await app.close();
+  });
+
+  it('returns 400 when days is not a positive integer', async () => {
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/kpi/summary?gameId=prompt-injection-arena&days=abc',
+    });
+
+    expect(res.statusCode).toBe(400);
+    await app.close();
+  });
+
+  it('returns 400 when days is zero', async () => {
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/kpi/summary?gameId=prompt-injection-arena&days=0',
+    });
+
+    expect(res.statusCode).toBe(400);
+    await app.close();
+  });
+
+  it('accepts optional ruleVersion query param', async () => {
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/kpi/summary?gameId=prompt-injection-arena&days=7&ruleVersion=1.0.0',
+    });
+
+    expect(res.statusCode).toBe(200);
+    await app.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /v1/kpi/diff
+// ---------------------------------------------------------------------------
+
+describe('GET /v1/kpi/diff', () => {
+  it('returns 200 with a KpiDiff object', async () => {
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/kpi/diff?gameId=prompt-injection-arena&ruleVersionA=1.0.0&ruleVersionB=1.1.0',
+    });
+
+    expect(res.statusCode).toBe(200);
+
+    const body = res.json<{ status: string; diff: unknown }>();
+    expect(body.status).toBe('ok');
+    expect(body.diff).toBeDefined();
+
+    await app.close();
+  });
+
+  it('returns 400 when gameId is missing', async () => {
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/kpi/diff?ruleVersionA=1.0.0&ruleVersionB=1.1.0',
+    });
+
+    expect(res.statusCode).toBe(400);
+    await app.close();
+  });
+
+  it('returns 400 when ruleVersionA is missing', async () => {
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/kpi/diff?gameId=prompt-injection-arena&ruleVersionB=1.1.0',
+    });
+
+    expect(res.statusCode).toBe(400);
+    await app.close();
+  });
+
+  it('returns 400 when ruleVersionB is missing', async () => {
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/kpi/diff?gameId=prompt-injection-arena&ruleVersionA=1.0.0',
+    });
+
+    expect(res.statusCode).toBe(400);
+    await app.close();
+  });
+});

--- a/apps/gateway/test/unit/services/kpi-aggregator.test.ts
+++ b/apps/gateway/test/unit/services/kpi-aggregator.test.ts
@@ -96,9 +96,9 @@ describe('KpiAggregator.computeCWR', () => {
       makeTurnEvent({ matchId: 'm2', seat: 'second', scoreDiffBefore: 3, scoreDiffAfter: 4 }),
     ];
 
-    expect(agg.computeCWR([comeback, frontRun], [...comebackEvents, ...frontRunEvents])).toBeCloseTo(
-      0.5,
-    );
+    expect(
+      agg.computeCWR([comeback, frontRun], [...comebackEvents, ...frontRunEvents]),
+    ).toBeCloseTo(0.5);
   });
 
   it('handles draw (no winnerId) by treating it as non-comeback win', () => {

--- a/apps/gateway/test/unit/services/kpi-aggregator.test.ts
+++ b/apps/gateway/test/unit/services/kpi-aggregator.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  KpiAggregator,
+  type MatchSummary,
+  type TurnEventSummary,
+  type ReturnEvent,
+} from '../../../src/services/kpi-aggregator.js';
+
+// ---------------------------------------------------------------------------
+// Test data factories
+// ---------------------------------------------------------------------------
+
+const makeMatch = (overrides: Partial<MatchSummary> = {}): MatchSummary => ({
+  matchId: 'match-1',
+  gameId: 'prompt-injection-arena',
+  ruleVersion: '1.0.0',
+  queueType: 'ranked',
+  ratingBracket: '1400-1600',
+  winnerId: 'agent-a',
+  finalScores: { 'agent-a': 60, 'agent-b': 40 },
+  durationMs: 120_000,
+  createdAt: '2026-03-01T10:00:00.000Z',
+  ...overrides,
+});
+
+const makeTurnEvent = (overrides: Partial<TurnEventSummary> = {}): TurnEventSummary => ({
+  matchId: 'match-1',
+  actionType: 'attack',
+  scoreDiffBefore: 0,
+  scoreDiffAfter: 5,
+  ...overrides,
+});
+
+const makeReturnEvent = (overrides: Partial<ReturnEvent> = {}): ReturnEvent => ({
+  uid: 'user-1',
+  returnedAt: '2026-03-02T10:00:00.000Z',
+  previousMatchAt: '2026-03-01T10:00:00.000Z', // 24h later → qualifies
+  ...overrides,
+});
+
+// ---------------------------------------------------------------------------
+// computeCMR – Competitive Match Rate
+// ---------------------------------------------------------------------------
+
+describe('KpiAggregator.computeCMR', () => {
+  const agg = new KpiAggregator();
+
+  it('returns 0 for an empty match list', () => {
+    expect(agg.computeCMR([])).toBe(0);
+  });
+
+  it('counts matches decided by ≤10% score difference', () => {
+    const competitive = makeMatch({ finalScores: { 'agent-a': 55, 'agent-b': 50 } }); // diff=5, max=55, 9.1%
+    const blowout = makeMatch({ finalScores: { 'agent-a': 80, 'agent-b': 20 } }); // diff=60, 75%
+    const result = agg.computeCMR([competitive, blowout]);
+    expect(result).toBeCloseTo(0.5);
+  });
+
+  it('treats a zero-score match as non-competitive to avoid division by zero', () => {
+    const zeroMatch = makeMatch({ finalScores: { 'agent-a': 0, 'agent-b': 0 } });
+    expect(agg.computeCMR([zeroMatch])).toBe(0);
+  });
+
+  it('handles all competitive matches', () => {
+    const matches = [
+      makeMatch({ matchId: 'm1', finalScores: { a: 51, b: 50 } }),
+      makeMatch({ matchId: 'm2', finalScores: { a: 100, b: 95 } }),
+    ];
+    expect(agg.computeCMR(matches)).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeCWR – Close Win Rate
+// ---------------------------------------------------------------------------
+
+describe('KpiAggregator.computeCWR', () => {
+  const agg = new KpiAggregator();
+
+  it('returns 0 for an empty match list', () => {
+    expect(agg.computeCWR([])).toBe(0);
+  });
+
+  it('counts wins where winner won by ≤20% of max possible score', () => {
+    // max = max(scores) = 60; diff = 20; 20/60 ≈ 33% → NOT close
+    const notClose = makeMatch({ finalScores: { 'agent-a': 60, 'agent-b': 40 } });
+    // max = 55; diff = 5; 5/55 ≈ 9% → close
+    const close = makeMatch({ finalScores: { 'agent-a': 55, 'agent-b': 50 } });
+
+    expect(agg.computeCWR([notClose, close])).toBeCloseTo(0.5);
+  });
+
+  it('handles draw (no winnerId) by treating it as non-close win', () => {
+    const draw = makeMatch({ winnerId: null, finalScores: { a: 50, b: 50 } });
+    expect(agg.computeCWR([draw])).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeADI – Action Diversity Index (Shannon entropy)
+// ---------------------------------------------------------------------------
+
+describe('KpiAggregator.computeADI', () => {
+  const agg = new KpiAggregator();
+
+  it('returns 0 for an empty event list', () => {
+    expect(agg.computeADI([])).toBe(0);
+  });
+
+  it('returns 0 when all actions are the same type', () => {
+    const events = [
+      makeTurnEvent({ actionType: 'attack' }),
+      makeTurnEvent({ actionType: 'attack' }),
+    ];
+    expect(agg.computeADI(events)).toBeCloseTo(0);
+  });
+
+  it('returns log2(n) for n equally-distributed action types', () => {
+    const events = [
+      makeTurnEvent({ actionType: 'attack' }),
+      makeTurnEvent({ actionType: 'defend' }),
+      makeTurnEvent({ actionType: 'negotiate' }),
+      makeTurnEvent({ actionType: 'flee' }),
+    ];
+    // H = log2(4) = 2
+    expect(agg.computeADI(events)).toBeCloseTo(2, 3);
+  });
+
+  it('produces a non-zero entropy for two different action types (50/50)', () => {
+    const events = [
+      makeTurnEvent({ actionType: 'attack' }),
+      makeTurnEvent({ actionType: 'defend' }),
+    ];
+    expect(agg.computeADI(events)).toBeCloseTo(1, 3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeRIR24 – Return In 24h Rate
+// ---------------------------------------------------------------------------
+
+describe('KpiAggregator.computeRIR24', () => {
+  const agg = new KpiAggregator();
+
+  it('returns 0 when there are no matches', () => {
+    expect(agg.computeRIR24([], [])).toBe(0);
+  });
+
+  it('returns 0 when there are no return events', () => {
+    expect(agg.computeRIR24([makeMatch()], [])).toBe(0);
+  });
+
+  it('counts users who returned within 24 h', () => {
+    const matches = [
+      makeMatch({ matchId: 'm1', createdAt: '2026-03-01T10:00:00.000Z' }),
+      makeMatch({ matchId: 'm2', createdAt: '2026-03-01T11:00:00.000Z' }),
+    ];
+    const returnEvents: ReturnEvent[] = [
+      {
+        uid: 'user-1',
+        previousMatchAt: '2026-03-01T10:00:00.000Z',
+        returnedAt: '2026-03-02T09:00:00.000Z', // 23h later → qualifies
+      },
+    ];
+    // 1 returner out of 2 matches → 0.5
+    expect(agg.computeRIR24(matches, returnEvents)).toBeCloseTo(0.5);
+  });
+
+  it('does not count users who returned after 24 h', () => {
+    const matches = [makeMatch({ matchId: 'm1', createdAt: '2026-03-01T10:00:00.000Z' })];
+    const returnEvents: ReturnEvent[] = [
+      {
+        uid: 'user-1',
+        previousMatchAt: '2026-03-01T10:00:00.000Z',
+        returnedAt: '2026-03-02T11:00:00.000Z', // 25h later → does not qualify
+      },
+    ];
+    expect(agg.computeRIR24(matches, returnEvents)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// aggregate – main aggregation function
+// ---------------------------------------------------------------------------
+
+describe('KpiAggregator.aggregate', () => {
+  const agg = new KpiAggregator();
+
+  it('returns a KpiSnapshot with all primary KPI metrics', () => {
+    const matches: MatchSummary[] = Array.from({ length: 10 }, (_, i) =>
+      makeMatch({
+        matchId: `m${i}`,
+        finalScores: { 'agent-a': 55, 'agent-b': 50 },
+      }),
+    );
+
+    const turnEvents: TurnEventSummary[] = [
+      makeTurnEvent({ actionType: 'attack' }),
+      makeTurnEvent({ actionType: 'defend' }),
+    ];
+
+    const snapshot = agg.aggregate({
+      gameId: 'prompt-injection-arena',
+      ruleVersion: '1.0.0',
+      queueType: 'ranked',
+      ratingBracket: '1400-1600',
+      period: '2026-03-01/2026-03-08',
+      matches,
+      turnEvents,
+      returnEvents: [],
+    });
+
+    expect(snapshot.gameId).toBe('prompt-injection-arena');
+    expect(snapshot.ruleVersion).toBe('1.0.0');
+    expect(snapshot.sampleSize).toBe(10);
+    expect(typeof snapshot.metrics.CMR).toBe('number');
+    expect(typeof snapshot.metrics.CWR).toBe('number');
+    expect(typeof snapshot.metrics.ADI).toBe('number');
+    expect(typeof snapshot.metrics.RIR24).toBe('number');
+    expect(typeof snapshot.computedAt).toBe('string');
+  });
+
+  it('attaches 95% confidence intervals for each metric', () => {
+    const matches: MatchSummary[] = Array.from({ length: 5 }, (_, i) =>
+      makeMatch({ matchId: `m${i}` }),
+    );
+
+    const snapshot = agg.aggregate({
+      gameId: 'prompt-injection-arena',
+      ruleVersion: '1.0.0',
+      queueType: 'ranked',
+      ratingBracket: '1400-1600',
+      period: '2026-03-01/2026-03-08',
+      matches,
+      turnEvents: [],
+      returnEvents: [],
+    });
+
+    for (const name of ['CMR', 'CWR', 'RIR24']) {
+      const ci = snapshot.confidence[name];
+      expect(ci).toBeDefined();
+      expect(Array.isArray(ci)).toBe(true);
+      expect(ci![0]).toBeLessThanOrEqual(snapshot.metrics[name]!);
+      expect(ci![1]).toBeGreaterThanOrEqual(snapshot.metrics[name]!);
+    }
+  });
+});

--- a/apps/gateway/test/unit/services/kpi-aggregator.test.ts
+++ b/apps/gateway/test/unit/services/kpi-aggregator.test.ts
@@ -18,6 +18,7 @@ const makeMatch = (overrides: Partial<MatchSummary> = {}): MatchSummary => ({
   queueType: 'ranked',
   ratingBracket: '1400-1600',
   winnerId: 'agent-a',
+  winnerSeat: 'first',
   finalScores: { 'agent-a': 60, 'agent-b': 40 },
   durationMs: 120_000,
   createdAt: '2026-03-01T10:00:00.000Z',
@@ -27,6 +28,7 @@ const makeMatch = (overrides: Partial<MatchSummary> = {}): MatchSummary => ({
 const makeTurnEvent = (overrides: Partial<TurnEventSummary> = {}): TurnEventSummary => ({
   matchId: 'match-1',
   actionType: 'attack',
+  seat: 'first',
   scoreDiffBefore: 0,
   scoreDiffAfter: 5,
   ...overrides,
@@ -34,6 +36,7 @@ const makeTurnEvent = (overrides: Partial<TurnEventSummary> = {}): TurnEventSumm
 
 const makeReturnEvent = (overrides: Partial<ReturnEvent> = {}): ReturnEvent => ({
   uid: 'user-1',
+  previousMatchId: 'match-1',
   returnedAt: '2026-03-02T10:00:00.000Z',
   previousMatchAt: '2026-03-01T10:00:00.000Z', // 24h later → qualifies
   ...overrides,
@@ -72,28 +75,35 @@ describe('KpiAggregator.computeCMR', () => {
 });
 
 // ---------------------------------------------------------------------------
-// computeCWR – Close Win Rate
+// computeCWR – Comeback Win Rate
 // ---------------------------------------------------------------------------
 
 describe('KpiAggregator.computeCWR', () => {
   const agg = new KpiAggregator();
 
   it('returns 0 for an empty match list', () => {
-    expect(agg.computeCWR([])).toBe(0);
+    expect(agg.computeCWR([], [])).toBe(0);
   });
 
-  it('counts wins where winner won by ≤20% of max possible score', () => {
-    // max = max(scores) = 60; diff = 20; 20/60 ≈ 33% → NOT close
-    const notClose = makeMatch({ finalScores: { 'agent-a': 60, 'agent-b': 40 } });
-    // max = 55; diff = 5; 5/55 ≈ 9% → close
-    const close = makeMatch({ finalScores: { 'agent-a': 55, 'agent-b': 50 } });
+  it('counts matches where the eventual winner was trailing before winning', () => {
+    const comeback = makeMatch({ matchId: 'm1', winnerSeat: 'first' });
+    const comebackEvents = [
+      makeTurnEvent({ matchId: 'm1', seat: 'first', scoreDiffBefore: -2, scoreDiffAfter: 1 }),
+    ];
 
-    expect(agg.computeCWR([notClose, close])).toBeCloseTo(0.5);
+    const frontRun = makeMatch({ matchId: 'm2', winnerSeat: 'second', winnerId: 'agent-b' });
+    const frontRunEvents = [
+      makeTurnEvent({ matchId: 'm2', seat: 'second', scoreDiffBefore: 3, scoreDiffAfter: 4 }),
+    ];
+
+    expect(agg.computeCWR([comeback, frontRun], [...comebackEvents, ...frontRunEvents])).toBeCloseTo(
+      0.5,
+    );
   });
 
-  it('handles draw (no winnerId) by treating it as non-close win', () => {
-    const draw = makeMatch({ winnerId: null, finalScores: { a: 50, b: 50 } });
-    expect(agg.computeCWR([draw])).toBe(0);
+  it('handles draw (no winnerId) by treating it as non-comeback win', () => {
+    const draw = makeMatch({ winnerId: null, winnerSeat: null, finalScores: { a: 50, b: 50 } });
+    expect(agg.computeCWR([draw], [makeTurnEvent({ scoreDiffBefore: -1 })])).toBe(0);
   });
 });
 
@@ -116,15 +126,14 @@ describe('KpiAggregator.computeADI', () => {
     expect(agg.computeADI(events)).toBeCloseTo(0);
   });
 
-  it('returns log2(n) for n equally-distributed action types', () => {
+  it('returns 1 for equally-distributed action types after normalization', () => {
     const events = [
       makeTurnEvent({ actionType: 'attack' }),
       makeTurnEvent({ actionType: 'defend' }),
       makeTurnEvent({ actionType: 'negotiate' }),
       makeTurnEvent({ actionType: 'flee' }),
     ];
-    // H = log2(4) = 2
-    expect(agg.computeADI(events)).toBeCloseTo(2, 3);
+    expect(agg.computeADI(events)).toBeCloseTo(1, 3);
   });
 
   it('produces a non-zero entropy for two different action types (50/50)', () => {
@@ -159,6 +168,7 @@ describe('KpiAggregator.computeRIR24', () => {
     const returnEvents: ReturnEvent[] = [
       {
         uid: 'user-1',
+        previousMatchId: 'm1',
         previousMatchAt: '2026-03-01T10:00:00.000Z',
         returnedAt: '2026-03-02T09:00:00.000Z', // 23h later → qualifies
       },
@@ -172,11 +182,22 @@ describe('KpiAggregator.computeRIR24', () => {
     const returnEvents: ReturnEvent[] = [
       {
         uid: 'user-1',
+        previousMatchId: 'm1',
         previousMatchAt: '2026-03-01T10:00:00.000Z',
         returnedAt: '2026-03-02T11:00:00.000Z', // 25h later → does not qualify
       },
     ];
     expect(agg.computeRIR24(matches, returnEvents)).toBe(0);
+  });
+
+  it('counts each prior match at most once even if multiple participants return', () => {
+    const matches = [makeMatch({ matchId: 'm1' })];
+    const returnEvents: ReturnEvent[] = [
+      makeReturnEvent({ uid: 'user-1', previousMatchId: 'm1' }),
+      makeReturnEvent({ uid: 'user-2', previousMatchId: 'm1' }),
+    ];
+
+    expect(agg.computeRIR24(matches, returnEvents)).toBe(1);
   });
 });
 
@@ -218,6 +239,8 @@ describe('KpiAggregator.aggregate', () => {
     expect(typeof snapshot.metrics.CWR).toBe('number');
     expect(typeof snapshot.metrics.ADI).toBe('number');
     expect(typeof snapshot.metrics.RIR24).toBe('number');
+    expect(snapshot.metrics.ADI).toBeGreaterThanOrEqual(0);
+    expect(snapshot.metrics.ADI).toBeLessThanOrEqual(1);
     expect(typeof snapshot.computedAt).toBe('string');
   });
 
@@ -244,5 +267,9 @@ describe('KpiAggregator.aggregate', () => {
       expect(ci![0]).toBeLessThanOrEqual(snapshot.metrics[name]!);
       expect(ci![1]).toBeGreaterThanOrEqual(snapshot.metrics[name]!);
     }
+
+    const adiCi = snapshot.confidence.ADI;
+    expect(adiCi[0]).toBeGreaterThanOrEqual(0);
+    expect(adiCi[1]).toBeLessThanOrEqual(1);
   });
 });

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -2,6 +2,7 @@ export const DOMAIN_PACKAGE_NAME = '@moltgames/domain';
 
 export * from './error-codes.js';
 export * from './firestore.js';
+export * from './kpi.js';
 export * from './match-status.js';
 export * from './types.js';
 export * from './value-guards.js';

--- a/packages/domain/src/kpi.ts
+++ b/packages/domain/src/kpi.ts
@@ -23,7 +23,7 @@
 export const PRIMARY_KPI_NAMES = ['CMR', 'CWR', 'ADI', 'RIR24'] as const;
 export type PrimaryKpiName = (typeof PRIMARY_KPI_NAMES)[number];
 
-export const GUARDRAIL_KPI_NAMES = ['MCR', 'FSWG', 'DSS', 'SR60', 'RCR80', 'DBT'] as const;
+export const GUARDRAIL_KPI_NAMES = ['MCR', 'TTFC', 'FSWG', 'DSS', 'SR60', 'RCR80', 'DBT'] as const;
 export type GuardrailKpiName = (typeof GUARDRAIL_KPI_NAMES)[number];
 
 export type KpiName = PrimaryKpiName | GuardrailKpiName;

--- a/packages/domain/src/kpi.ts
+++ b/packages/domain/src/kpi.ts
@@ -1,0 +1,122 @@
+/**
+ * KPI type definitions for gameplay measurement (PR-18b).
+ *
+ * Primary KPIs:
+ *   CMR  – Competitive Match Rate
+ *   CWR  – Close Win Rate
+ *   ADI  – Action Diversity Index
+ *   RIR24 – Return In 24 h Rate
+ *
+ * Guardrail KPIs:
+ *   MCR   – Match Completion Rate
+ *   FSWG  – First-Start Win Gap
+ *   DSS   – Draw / Stalemate Share
+ *   SR60  – Session Retention 60 min
+ *   RCR80 – Rule Compliance Rate 80 %
+ *   DBT   – Decision Boundary Traversal
+ */
+
+// ---------------------------------------------------------------------------
+// Metric name constants
+// ---------------------------------------------------------------------------
+
+export const PRIMARY_KPI_NAMES = ['CMR', 'CWR', 'ADI', 'RIR24'] as const;
+export type PrimaryKpiName = (typeof PRIMARY_KPI_NAMES)[number];
+
+export const GUARDRAIL_KPI_NAMES = ['MCR', 'FSWG', 'DSS', 'SR60', 'RCR80', 'DBT'] as const;
+export type GuardrailKpiName = (typeof GUARDRAIL_KPI_NAMES)[number];
+
+export type KpiName = PrimaryKpiName | GuardrailKpiName;
+
+// ---------------------------------------------------------------------------
+// KpiSnapshot
+// ---------------------------------------------------------------------------
+
+/**
+ * A point-in-time snapshot of computed KPI metrics for a given game /
+ * rule version / queue-type / rating bracket / time period.
+ */
+export interface KpiSnapshot {
+  readonly gameId: string;
+  readonly ruleVersion: string;
+  readonly queueType: string;
+  readonly ratingBracket: string;
+  /** ISO-8601 period identifier, e.g. "2026-03-01/2026-03-08" */
+  readonly period: string;
+  readonly sampleSize: number;
+  /** Metric name → value (0–1 ratio or entropy score) */
+  readonly metrics: Readonly<Record<string, number>>;
+  /** Metric name → [lower, upper] 95 % confidence interval */
+  readonly confidence: Readonly<Record<string, readonly [number, number]>>;
+  readonly computedAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// KpiDiff
+// ---------------------------------------------------------------------------
+
+export interface KpiMetricDiff {
+  readonly metricName: string;
+  readonly valueA: number;
+  readonly valueB: number;
+  readonly absoluteDiff: number;
+  readonly relativeDiff: number;
+  /** Whether the difference is statistically significant */
+  readonly significant: boolean;
+}
+
+export interface KpiDiff {
+  readonly gameId: string;
+  readonly ruleVersionA: string;
+  readonly ruleVersionB: string;
+  readonly sampleSizeA: number;
+  readonly sampleSizeB: number;
+  readonly diffs: readonly KpiMetricDiff[];
+  readonly computedAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Pure helper functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true when the sample size meets the minimum threshold for
+ * statistical significance (default N ≥ 400 per SPEC §18b).
+ */
+export const isStatisticallySignificant = (sampleSize: number, minN = 400): boolean =>
+  sampleSize >= minN;
+
+/**
+ * Computes a per-metric diff between two KpiSnapshots.
+ * Only metrics present in *both* snapshots are included.
+ */
+export const computeKpiDiff = (a: KpiSnapshot, b: KpiSnapshot): KpiDiff => {
+  const metricNames = Object.keys(a.metrics).filter((name) => name in b.metrics);
+
+  const diffs: KpiMetricDiff[] = metricNames.map((name) => {
+    const valueA = a.metrics[name] ?? 0;
+    const valueB = b.metrics[name] ?? 0;
+    const absoluteDiff = valueB - valueA;
+    const relativeDiff = valueA === 0 ? 0 : absoluteDiff / valueA;
+
+    return {
+      metricName: name,
+      valueA,
+      valueB,
+      absoluteDiff,
+      relativeDiff,
+      significant:
+        isStatisticallySignificant(a.sampleSize) && isStatisticallySignificant(b.sampleSize),
+    };
+  });
+
+  return {
+    gameId: a.gameId,
+    ruleVersionA: a.ruleVersion,
+    ruleVersionB: b.ruleVersion,
+    sampleSizeA: a.sampleSize,
+    sampleSizeB: b.sampleSize,
+    diffs,
+    computedAt: new Date().toISOString(),
+  };
+};

--- a/packages/domain/test/unit/kpi.test.ts
+++ b/packages/domain/test/unit/kpi.test.ts
@@ -40,7 +40,7 @@ describe('KPI name constants', () => {
   });
 
   it('exposes the six guardrail KPI names', () => {
-    expect(GUARDRAIL_KPI_NAMES).toEqual(['MCR', 'FSWG', 'DSS', 'SR60', 'RCR80', 'DBT']);
+    expect(GUARDRAIL_KPI_NAMES).toEqual(['MCR', 'TTFC', 'FSWG', 'DSS', 'SR60', 'RCR80', 'DBT']);
   });
 });
 

--- a/packages/domain/test/unit/kpi.test.ts
+++ b/packages/domain/test/unit/kpi.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  computeKpiDiff,
+  isStatisticallySignificant,
+  PRIMARY_KPI_NAMES,
+  GUARDRAIL_KPI_NAMES,
+  type KpiSnapshot,
+} from '../../src/kpi.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const makeSnapshot = (overrides: Partial<KpiSnapshot> = {}): KpiSnapshot => ({
+  gameId: 'prompt-injection-arena',
+  ruleVersion: '1.0.0',
+  queueType: 'ranked',
+  ratingBracket: '1400-1600',
+  period: '2026-03-01/2026-03-08',
+  sampleSize: 500,
+  metrics: { CMR: 0.6, CWR: 0.55, ADI: 2.3, RIR24: 0.4 },
+  confidence: {
+    CMR: [0.55, 0.65],
+    CWR: [0.5, 0.6],
+    ADI: [2.1, 2.5],
+    RIR24: [0.35, 0.45],
+  },
+  computedAt: '2026-03-09T00:00:00.000Z',
+  ...overrides,
+});
+
+// ---------------------------------------------------------------------------
+// KPI name constants
+// ---------------------------------------------------------------------------
+
+describe('KPI name constants', () => {
+  it('exposes the four primary KPI names', () => {
+    expect(PRIMARY_KPI_NAMES).toEqual(['CMR', 'CWR', 'ADI', 'RIR24']);
+  });
+
+  it('exposes the six guardrail KPI names', () => {
+    expect(GUARDRAIL_KPI_NAMES).toEqual(['MCR', 'FSWG', 'DSS', 'SR60', 'RCR80', 'DBT']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isStatisticallySignificant
+// ---------------------------------------------------------------------------
+
+describe('isStatisticallySignificant', () => {
+  it('returns true when sample size meets default minimum (400)', () => {
+    expect(isStatisticallySignificant(400)).toBe(true);
+    expect(isStatisticallySignificant(500)).toBe(true);
+    expect(isStatisticallySignificant(1000)).toBe(true);
+  });
+
+  it('returns false when sample size is below default minimum', () => {
+    expect(isStatisticallySignificant(399)).toBe(false);
+    expect(isStatisticallySignificant(0)).toBe(false);
+    expect(isStatisticallySignificant(1)).toBe(false);
+  });
+
+  it('respects a custom minN parameter', () => {
+    expect(isStatisticallySignificant(100, 100)).toBe(true);
+    expect(isStatisticallySignificant(99, 100)).toBe(false);
+    expect(isStatisticallySignificant(50, 30)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeKpiDiff
+// ---------------------------------------------------------------------------
+
+describe('computeKpiDiff', () => {
+  it('computes absolute and relative diffs for matching metrics', () => {
+    const a = makeSnapshot({ ruleVersion: '1.0.0', metrics: { CMR: 0.5, CWR: 0.6 } });
+    const b = makeSnapshot({ ruleVersion: '1.1.0', metrics: { CMR: 0.6, CWR: 0.6 } });
+
+    const diff = computeKpiDiff(a, b);
+
+    expect(diff.ruleVersionA).toBe('1.0.0');
+    expect(diff.ruleVersionB).toBe('1.1.0');
+    expect(diff.gameId).toBe('prompt-injection-arena');
+    expect(diff.sampleSizeA).toBe(500);
+    expect(diff.sampleSizeB).toBe(500);
+
+    const cmrDiff = diff.diffs.find((d) => d.metricName === 'CMR');
+    expect(cmrDiff).toBeDefined();
+    expect(cmrDiff?.valueA).toBeCloseTo(0.5);
+    expect(cmrDiff?.valueB).toBeCloseTo(0.6);
+    expect(cmrDiff?.absoluteDiff).toBeCloseTo(0.1);
+    expect(cmrDiff?.relativeDiff).toBeCloseTo(0.2); // 0.1 / 0.5
+
+    const cwrDiff = diff.diffs.find((d) => d.metricName === 'CWR');
+    expect(cwrDiff?.absoluteDiff).toBeCloseTo(0);
+  });
+
+  it('marks diff as significant when both snapshots have sample size >= 400', () => {
+    const a = makeSnapshot({ sampleSize: 400 });
+    const b = makeSnapshot({ sampleSize: 500 });
+
+    const diff = computeKpiDiff(a, b);
+    diff.diffs.forEach((d) => expect(d.significant).toBe(true));
+  });
+
+  it('marks diff as not significant when either snapshot is below 400', () => {
+    const a = makeSnapshot({ sampleSize: 399 });
+    const b = makeSnapshot({ sampleSize: 500 });
+
+    const diff = computeKpiDiff(a, b);
+    diff.diffs.forEach((d) => expect(d.significant).toBe(false));
+  });
+
+  it('only includes metrics present in both snapshots', () => {
+    const a = makeSnapshot({ metrics: { CMR: 0.5, CWR: 0.6, ADI: 1.8 } });
+    const b = makeSnapshot({ metrics: { CMR: 0.55, ADI: 2.0 } }); // CWR missing in b
+
+    const diff = computeKpiDiff(a, b);
+    const names = diff.diffs.map((d) => d.metricName);
+
+    expect(names).toContain('CMR');
+    expect(names).toContain('ADI');
+    expect(names).not.toContain('CWR');
+  });
+
+  it('handles zero baseValue without division errors (relativeDiff = 0)', () => {
+    const a = makeSnapshot({ metrics: { CMR: 0 } });
+    const b = makeSnapshot({ metrics: { CMR: 0.1 } });
+
+    const diff = computeKpiDiff(a, b);
+    const cmrDiff = diff.diffs.find((d) => d.metricName === 'CMR');
+
+    expect(cmrDiff?.relativeDiff).toBe(0);
+    expect(cmrDiff?.absoluteDiff).toBeCloseTo(0.1);
+  });
+
+  it('includes a computedAt ISO timestamp', () => {
+    const diff = computeKpiDiff(makeSnapshot(), makeSnapshot({ ruleVersion: '2.0.0' }));
+    expect(typeof diff.computedAt).toBe('string');
+    expect(() => new Date(diff.computedAt)).not.toThrow();
+  });
+
+  it('produces an empty diffs array when there are no common metrics', () => {
+    const a = makeSnapshot({ metrics: { CMR: 0.5 } });
+    const b = makeSnapshot({ metrics: { CWR: 0.6 } });
+
+    const diff = computeKpiDiff(a, b);
+    expect(diff.diffs).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Add KPI type definitions (`CMR`, `CWR`, `ADI`, `RIR24` primary + 6 guardrail KPIs: `MCR`, `FSWG`, `DSS`, `SR60`, `RCR80`, `DBT`) to `@moltgames/domain`
- Implement `KpiAggregator` service with pure, testable functions: `computeCMR`, `computeCWR`, `computeADI` (Shannon entropy), `computeRIR24`, and `aggregate()` with Wilson-score 95% confidence intervals (N≥400 significance threshold)
- Add `GET /v1/kpi/summary` and `GET /v1/kpi/diff` API endpoints (stub in-memory data with clear TODO comments for Firestore pipeline in PR-18c)

Implements PR-18b from PLAN.md. Dependencies: PR-12 ✅, PR-13 ✅

## Test plan
- [ ] `pnpm --filter @moltgames/domain test:unit` passes (12 new KPI tests + 13 existing = 25)
- [ ] `pnpm --filter @moltgames/gateway test:unit` passes (17 aggregator + 8 route tests added; 139 total)
- [ ] `pnpm typecheck` passes with no errors
- [ ] `pnpm lint` passes with no warnings
- [ ] `pnpm build` succeeds end-to-end
- [ ] Coverage ≥ 80% (all new files are fully tested)

🤖 Generated with [Claude Code](https://claude.com/claude-code)