### PR TITLE
feat(gateway): anti-cheat detection and admin review endpoints

### DIFF
--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -72,6 +72,7 @@ import {
 } from './spectator/latency-recorder.js';
 import { RedisMatchActionRateLimiter } from './websocket/match-action-rate-limiter.js';
 import { sendRestApiError } from './api-error.js';
+import { registerAdminRoutes } from './routes/admin.js';
 
 class MockFirebaseVerifier implements FirebaseIdTokenVerifier {
   async verifyIdToken(_idToken: string): Promise<VerifiedFirebaseIdToken> {
@@ -1842,6 +1843,12 @@ export const createApp = async (options: AppOptions = {}) => {
       });
     },
   );
+
+  const adminRouteRedis = process.env.NODE_ENV === 'test' && !options.redis ? undefined : redis;
+  await registerAdminRoutes(app, {
+    ...(internalTaskAuthToken !== undefined ? { internalTaskAuthToken } : {}),
+    ...(adminRouteRedis !== undefined ? { redis: adminRouteRedis } : {}),
+  });
 
   app.addHook('onClose', async () => {
     for (const session of sessionsById.values()) {

--- a/apps/gateway/src/routes/admin.ts
+++ b/apps/gateway/src/routes/admin.ts
@@ -1,0 +1,170 @@
+import { timingSafeEqual } from 'node:crypto';
+
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+
+import type { ReviewStatus, SuspiciousMatchFlag } from '../services/suspicious-match.js';
+import {
+  InMemorySuspiciousMatchStore,
+  SuspiciousMatchStore,
+} from '../services/suspicious-match.js';
+import type { Redis } from 'ioredis';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const getBearerToken = (header: string | undefined): string | null => {
+  if (typeof header !== 'string') return null;
+  const parts = header.split(' ');
+  if (parts.length !== 2 || parts[0]?.toLowerCase() !== 'bearer') return null;
+  return parts[1] ?? null;
+};
+
+const isSecretMatch = (actual: string, expected: string): boolean => {
+  const a = Buffer.from(actual);
+  const e = Buffer.from(expected);
+  if (a.length !== e.length) return false;
+  return timingSafeEqual(a, e);
+};
+
+const VALID_REVIEW_STATUSES: readonly ReviewStatus[] = ['reviewed', 'cleared'];
+
+const isReviewStatus = (value: unknown): value is ReviewStatus =>
+  VALID_REVIEW_STATUSES.includes(value as ReviewStatus);
+
+// ---------------------------------------------------------------------------
+// Store type (allows injection in tests)
+// ---------------------------------------------------------------------------
+
+export type SuspiciousMatchStoreInterface = {
+  flag(
+    matchId: string,
+    reason: string,
+    flaggedBy?: 'system' | 'admin',
+  ): Promise<SuspiciousMatchFlag>;
+  get(matchId: string): Promise<SuspiciousMatchFlag | null>;
+  update(
+    matchId: string,
+    patch: Partial<Pick<SuspiciousMatchFlag, 'reviewStatus' | 'reviewedAt' | 'reviewNote'>>,
+  ): Promise<SuspiciousMatchFlag | null>;
+  listAll(): Promise<SuspiciousMatchFlag[]>;
+};
+
+// ---------------------------------------------------------------------------
+// Plugin
+// ---------------------------------------------------------------------------
+
+export interface AdminRoutesOptions {
+  internalTaskAuthToken?: string;
+  suspiciousMatchStore?: SuspiciousMatchStoreInterface;
+  redis?: Redis;
+}
+
+export async function registerAdminRoutes(
+  app: FastifyInstance,
+  opts: AdminRoutesOptions,
+): Promise<void> {
+  const { internalTaskAuthToken } = opts;
+
+  // Choose store: prefer injected, then Redis-backed (prod), then in-memory (test)
+  const store: SuspiciousMatchStoreInterface =
+    opts.suspiciousMatchStore ??
+    (opts.redis !== undefined
+      ? new SuspiciousMatchStore(opts.redis)
+      : new InMemorySuspiciousMatchStore());
+
+  // ---------------------------------------------------------------------------
+  // Auth pre-handler
+  // ---------------------------------------------------------------------------
+  const requireAdminAuth = (request: FastifyRequest, reply: FastifyReply): void => {
+    const authHeader =
+      typeof request.headers.authorization === 'string' ? request.headers.authorization : undefined;
+    const token = getBearerToken(authHeader);
+
+    if (internalTaskAuthToken === undefined) {
+      reply.status(401).send({ status: 'error', message: 'Admin auth is not configured' });
+      return;
+    }
+
+    if (token === null || !isSecretMatch(token, internalTaskAuthToken)) {
+      reply.status(401).send({ status: 'error', message: 'Unauthorized' });
+    }
+  };
+
+  // ---------------------------------------------------------------------------
+  // POST /v1/admin/matches/:matchId/flag
+  // ---------------------------------------------------------------------------
+  app.post<{
+    Params: { matchId: string };
+    Body: { reason?: unknown };
+  }>('/v1/admin/matches/:matchId/flag', async (request, reply) => {
+    requireAdminAuth(request, reply);
+    if (reply.sent) return;
+
+    const { matchId } = request.params;
+    const { reason } = request.body;
+
+    if (typeof reason !== 'string' || reason.trim().length === 0) {
+      reply.status(400).send({ status: 'error', message: '"reason" must be a non-empty string' });
+      return;
+    }
+
+    const flag = await store.flag(matchId, reason.trim(), 'admin');
+    return { status: 'ok', matchId, flag };
+  });
+
+  // ---------------------------------------------------------------------------
+  // GET /v1/admin/matches/flagged
+  // ---------------------------------------------------------------------------
+  app.get('/v1/admin/matches/flagged', async (request, reply) => {
+    requireAdminAuth(request, reply);
+    if (reply.sent) return;
+
+    const flags = await store.listAll();
+    return { status: 'ok', flags };
+  });
+
+  // ---------------------------------------------------------------------------
+  // POST /v1/admin/matches/:matchId/review
+  // ---------------------------------------------------------------------------
+  app.post<{
+    Params: { matchId: string };
+    Body: { status?: unknown; note?: unknown };
+  }>('/v1/admin/matches/:matchId/review', async (request, reply) => {
+    requireAdminAuth(request, reply);
+    if (reply.sent) return;
+
+    const { matchId } = request.params;
+    const { status, note } = request.body;
+
+    if (!isReviewStatus(status)) {
+      reply.status(400).send({
+        status: 'error',
+        message: `"status" must be one of: ${VALID_REVIEW_STATUSES.join(', ')}`,
+      });
+      return;
+    }
+
+    if (note !== undefined && typeof note !== 'string') {
+      reply.status(400).send({ status: 'error', message: '"note" must be a string if provided' });
+      return;
+    }
+
+    const patch: Parameters<typeof store.update>[1] = {
+      reviewStatus: status,
+      reviewedAt: new Date().toISOString(),
+    };
+    if (typeof note === 'string') {
+      patch.reviewNote = note;
+    }
+
+    const updated = await store.update(matchId, patch);
+
+    if (updated === null) {
+      reply.status(404).send({ status: 'error', message: `Match ${matchId} is not flagged` });
+      return;
+    }
+
+    return { status: 'ok', matchId, flag: updated };
+  });
+}

--- a/apps/gateway/src/services/anti-cheat.ts
+++ b/apps/gateway/src/services/anti-cheat.ts
@@ -118,11 +118,7 @@ export class SelfPlayDetector {
         };
       }
 
-      if (
-        ip.trim().length > 0 &&
-        participant.ip.trim().length > 0 &&
-        participant.ip === ip
-      ) {
+      if (ip.trim().length > 0 && participant.ip.trim().length > 0 && participant.ip === ip) {
         return {
           blocked: true,
           reason: `ip ${ip} is already participating in this match`,

--- a/apps/gateway/src/services/anti-cheat.ts
+++ b/apps/gateway/src/services/anti-cheat.ts
@@ -1,0 +1,170 @@
+import { createHash } from 'node:crypto';
+
+import type { Redis } from 'ioredis';
+
+const ACTION_STATE_KEY_PREFIX = 'anticheat:action-state:';
+
+// ---------------------------------------------------------------------------
+// AnomalousSpeedDetector
+// ---------------------------------------------------------------------------
+
+export interface SpeedCheckResult {
+  flagged: boolean;
+  reason?: string;
+}
+
+interface ActionState {
+  lastTimestamp: number;
+  streak: number; // number of consecutive rapid actions (including last)
+}
+
+/**
+ * Detects agents submitting actions unusually fast (< thresholdMs between
+ * consecutive actions).  State (last timestamp + running streak) is stored in
+ * Redis per match+agent pair.
+ *
+ * A "slow" action (gap >= thresholdMs) resets the streak to 1.
+ * When streak reaches consecutiveCount the call returns flagged=true.
+ */
+export class AnomalousSpeedDetector {
+  readonly #redis: Redis;
+
+  constructor(redis: Redis) {
+    this.#redis = redis;
+  }
+
+  async checkAction(
+    matchId: string,
+    agentId: string,
+    thresholdMs = 100,
+    consecutiveCount = 3,
+    nowMs: number = Date.now(),
+  ): Promise<SpeedCheckResult> {
+    const key = `${ACTION_STATE_KEY_PREFIX}${matchId}:${agentId}`;
+    const raw = await this.#redis.get(key);
+
+    let streak: number;
+
+    if (raw === null) {
+      // First action for this agent in this match
+      streak = 1;
+    } else {
+      const state = JSON.parse(raw) as ActionState;
+      const gap = nowMs - state.lastTimestamp;
+
+      if (gap < thresholdMs) {
+        // Rapid action — extend the streak
+        streak = state.streak + 1;
+      } else {
+        // Slow action — reset streak
+        streak = 1;
+      }
+    }
+
+    const newState: ActionState = { lastTimestamp: nowMs, streak };
+    // Keep state for 24 hours (matches should not last longer)
+    await this.#redis.set(key, JSON.stringify(newState), 'EX', 86400);
+
+    if (streak >= consecutiveCount) {
+      return {
+        flagged: true,
+        reason: `Agent submitted ${consecutiveCount} consecutive actions faster than ${thresholdMs}ms`,
+      };
+    }
+
+    return { flagged: false };
+  }
+
+  /** Remove all stored state for a match (call on match end). */
+  async clearMatch(matchId: string): Promise<void> {
+    const keys = await this.#redis.keys(`${ACTION_STATE_KEY_PREFIX}${matchId}:*`);
+    if (keys.length > 0) {
+      await this.#redis.del(...keys);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// SelfPlayDetector
+// ---------------------------------------------------------------------------
+
+export interface SelfPlayCheckResult {
+  blocked: boolean;
+  reason?: string;
+}
+
+export interface ActiveParticipant {
+  uid: string;
+  ip: string;
+}
+
+/**
+ * Prevents the same user account or same client IP from occupying both sides
+ * of a match (self-play / Sybil attack).
+ *
+ * Stateless — the caller supplies the current list of active participants.
+ */
+export class SelfPlayDetector {
+  checkEnqueue(
+    uid: string,
+    ip: string,
+    activeParticipants: readonly ActiveParticipant[],
+  ): SelfPlayCheckResult {
+    for (const participant of activeParticipants) {
+      if (participant.uid === uid) {
+        return {
+          blocked: true,
+          reason: `uid ${uid} is already a participant in this match`,
+        };
+      }
+
+      if (participant.ip === ip) {
+        return {
+          blocked: true,
+          reason: `ip ${ip} is already participating in this match`,
+        };
+      }
+    }
+
+    return { blocked: false };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ReplayIntegrityChecker helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute SHA-256( prevHash || actionData ) and return the hex digest.
+ */
+export function computeEventHash(prevHash: string, actionData: string): string {
+  return createHash('sha256').update(prevHash).update(actionData).digest('hex');
+}
+
+export interface EventChainEntry {
+  hash: string;
+  actionData: string;
+  prevHash: string;
+}
+
+export interface ChainVerificationResult {
+  valid: boolean;
+  firstInvalidIndex?: number;
+}
+
+/**
+ * Walk the event chain and verify each entry's hash matches
+ * SHA-256( entry.prevHash || entry.actionData ).
+ */
+export function verifyEventChain(events: readonly EventChainEntry[]): ChainVerificationResult {
+  for (let i = 0; i < events.length; i++) {
+    const event = events[i];
+    if (event === undefined) continue;
+    const expected = computeEventHash(event.prevHash, event.actionData);
+    if (event.hash !== expected) {
+      return { valid: false, firstInvalidIndex: i };
+    }
+  }
+
+  return { valid: true };
+}

--- a/apps/gateway/src/services/anti-cheat.ts
+++ b/apps/gateway/src/services/anti-cheat.ts
@@ -118,7 +118,11 @@ export class SelfPlayDetector {
         };
       }
 
-      if (participant.ip === ip) {
+      if (
+        ip.trim().length > 0 &&
+        participant.ip.trim().length > 0 &&
+        participant.ip === ip
+      ) {
         return {
           blocked: true,
           reason: `ip ${ip} is already participating in this match`,
@@ -160,6 +164,12 @@ export function verifyEventChain(events: readonly EventChainEntry[]): ChainVerif
   for (let i = 0; i < events.length; i++) {
     const event = events[i];
     if (event === undefined) continue;
+
+    const previousEvent = i === 0 ? undefined : events[i - 1];
+    if (previousEvent !== undefined && event.prevHash !== previousEvent.hash) {
+      return { valid: false, firstInvalidIndex: i };
+    }
+
     const expected = computeEventHash(event.prevHash, event.actionData);
     if (event.hash !== expected) {
       return { valid: false, firstInvalidIndex: i };

--- a/apps/gateway/src/services/suspicious-match.ts
+++ b/apps/gateway/src/services/suspicious-match.ts
@@ -1,0 +1,128 @@
+import type { Redis } from 'ioredis';
+
+const SUSPICIOUS_KEY_PREFIX = 'suspicious:match:';
+const FLAG_TTL_SECONDS = 30 * 24 * 60 * 60; // 30 days
+
+export type ReviewStatus = 'pending' | 'reviewed' | 'cleared';
+
+export interface SuspiciousMatchFlag {
+  matchId: string;
+  flaggedAt: string; // ISO 8601
+  reason: string;
+  flaggedBy: 'system' | 'admin';
+  reviewStatus: ReviewStatus;
+  reviewedAt?: string;
+  reviewNote?: string;
+}
+
+const buildKey = (matchId: string): string => `${SUSPICIOUS_KEY_PREFIX}${matchId}`;
+
+export class SuspiciousMatchStore {
+  readonly #redis: Redis;
+
+  constructor(redis: Redis) {
+    this.#redis = redis;
+  }
+
+  async flag(
+    matchId: string,
+    reason: string,
+    flaggedBy: 'system' | 'admin' = 'admin',
+  ): Promise<SuspiciousMatchFlag> {
+    const flag: SuspiciousMatchFlag = {
+      matchId,
+      flaggedAt: new Date().toISOString(),
+      reason,
+      flaggedBy,
+      reviewStatus: 'pending',
+    };
+
+    await this.#redis.set(buildKey(matchId), JSON.stringify(flag), 'EX', FLAG_TTL_SECONDS);
+    return flag;
+  }
+
+  async get(matchId: string): Promise<SuspiciousMatchFlag | null> {
+    const raw = await this.#redis.get(buildKey(matchId));
+    if (raw === null) return null;
+    return JSON.parse(raw) as SuspiciousMatchFlag;
+  }
+
+  async update(
+    matchId: string,
+    patch: Partial<Pick<SuspiciousMatchFlag, 'reviewStatus' | 'reviewedAt' | 'reviewNote'>>,
+  ): Promise<SuspiciousMatchFlag | null> {
+    const existing = await this.get(matchId);
+    if (existing === null) return null;
+
+    const updated: SuspiciousMatchFlag = { ...existing, ...patch };
+    await this.#redis.set(buildKey(matchId), JSON.stringify(updated), 'EX', FLAG_TTL_SECONDS);
+    return updated;
+  }
+
+  /** Scan Redis for all flagged match keys (uses SCAN for safety). */
+  async listAll(): Promise<SuspiciousMatchFlag[]> {
+    const flags: SuspiciousMatchFlag[] = [];
+    let cursor = '0';
+
+    do {
+      const [nextCursor, keys] = await this.#redis.scan(
+        cursor,
+        'MATCH',
+        `${SUSPICIOUS_KEY_PREFIX}*`,
+        'COUNT',
+        100,
+      );
+      cursor = nextCursor;
+
+      for (const key of keys) {
+        const raw = await this.#redis.get(key);
+        if (raw !== null) {
+          flags.push(JSON.parse(raw) as SuspiciousMatchFlag);
+        }
+      }
+    } while (cursor !== '0');
+
+    return flags;
+  }
+}
+
+// In-memory implementation for tests (no Redis dependency)
+export class InMemorySuspiciousMatchStore {
+  readonly #data = new Map<string, SuspiciousMatchFlag>();
+
+  async flag(
+    matchId: string,
+    reason: string,
+    flaggedBy: 'system' | 'admin' = 'admin',
+  ): Promise<SuspiciousMatchFlag> {
+    const flag: SuspiciousMatchFlag = {
+      matchId,
+      flaggedAt: new Date().toISOString(),
+      reason,
+      flaggedBy,
+      reviewStatus: 'pending',
+    };
+    this.#data.set(matchId, flag);
+    return flag;
+  }
+
+  async get(matchId: string): Promise<SuspiciousMatchFlag | null> {
+    return this.#data.get(matchId) ?? null;
+  }
+
+  async update(
+    matchId: string,
+    patch: Partial<Pick<SuspiciousMatchFlag, 'reviewStatus' | 'reviewedAt' | 'reviewNote'>>,
+  ): Promise<SuspiciousMatchFlag | null> {
+    const existing = this.#data.get(matchId);
+    if (existing === undefined) return null;
+
+    const updated: SuspiciousMatchFlag = { ...existing, ...patch };
+    this.#data.set(matchId, updated);
+    return updated;
+  }
+
+  async listAll(): Promise<SuspiciousMatchFlag[]> {
+    return [...this.#data.values()];
+  }
+}

--- a/apps/gateway/test/unit/routes/admin.test.ts
+++ b/apps/gateway/test/unit/routes/admin.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+
+import { createApp } from '../../../src/app.js';
+
+vi.mock('firebase-admin/app', () => ({
+  getApps: vi.fn(() => []),
+  initializeApp: vi.fn(),
+}));
+
+vi.mock('firebase-admin/auth', () => ({
+  getAuth: vi.fn(() => ({})),
+}));
+
+const VALID_TOKEN = 'test-admin-token-secret';
+
+async function buildApp() {
+  const app = await createApp({
+    internalTaskAuthToken: VALID_TOKEN,
+  });
+  return app;
+}
+
+describe('Admin routes – authentication', () => {
+  let app: Awaited<ReturnType<typeof buildApp>>;
+
+  beforeEach(async () => {
+    process.env.NODE_ENV = 'test';
+    app = await buildApp();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('POST /v1/admin/matches/:matchId/flag returns 401 when no auth header', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/admin/matches/match-abc/flag',
+      payload: { reason: 'suspicious' },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('POST /v1/admin/matches/:matchId/flag returns 401 for wrong token', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/admin/matches/match-abc/flag',
+      headers: { authorization: 'Bearer wrong-token' },
+      payload: { reason: 'suspicious' },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('GET /v1/admin/matches/flagged returns 401 when no auth header', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/admin/matches/flagged',
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('POST /v1/admin/matches/:matchId/review returns 401 for wrong token', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/admin/matches/match-abc/review',
+      headers: { authorization: 'Bearer wrong-token' },
+      payload: { status: 'reviewed' },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+describe('Admin routes – flag endpoint', () => {
+  let app: Awaited<ReturnType<typeof buildApp>>;
+
+  beforeEach(async () => {
+    process.env.NODE_ENV = 'test';
+    app = await buildApp();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('POST /v1/admin/matches/:matchId/flag returns 200 and stores flag with valid token', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/admin/matches/match-xyz/flag',
+      headers: { authorization: `Bearer ${VALID_TOKEN}` },
+      payload: { reason: 'anomalous speed detected' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body) as { status: string; matchId: string };
+    expect(body.status).toBe('ok');
+    expect(body.matchId).toBe('match-xyz');
+  });
+
+  it('POST /v1/admin/matches/:matchId/flag returns 400 when reason is missing', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/admin/matches/match-xyz/flag',
+      headers: { authorization: `Bearer ${VALID_TOKEN}` },
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe('Admin routes – flagged list endpoint', () => {
+  let app: Awaited<ReturnType<typeof buildApp>>;
+
+  beforeEach(async () => {
+    process.env.NODE_ENV = 'test';
+    app = await buildApp();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('GET /v1/admin/matches/flagged returns 200 and list with valid token', async () => {
+    // Flag a match first
+    await app.inject({
+      method: 'POST',
+      url: '/v1/admin/matches/match-list-1/flag',
+      headers: { authorization: `Bearer ${VALID_TOKEN}` },
+      payload: { reason: 'test flag' },
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/admin/matches/flagged',
+      headers: { authorization: `Bearer ${VALID_TOKEN}` },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body) as { status: string; flags: unknown[] };
+    expect(body.status).toBe('ok');
+    expect(Array.isArray(body.flags)).toBe(true);
+  });
+});
+
+describe('Admin routes – review endpoint', () => {
+  let app: Awaited<ReturnType<typeof buildApp>>;
+
+  beforeEach(async () => {
+    process.env.NODE_ENV = 'test';
+    app = await buildApp();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('POST /v1/admin/matches/:matchId/review returns 404 when match not flagged', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/admin/matches/nonexistent/review',
+      headers: { authorization: `Bearer ${VALID_TOKEN}` },
+      payload: { status: 'reviewed', note: 'looked fine' },
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('POST /v1/admin/matches/:matchId/review returns 200 and updates flag', async () => {
+    // Flag the match first
+    await app.inject({
+      method: 'POST',
+      url: '/v1/admin/matches/match-review-1/flag',
+      headers: { authorization: `Bearer ${VALID_TOKEN}` },
+      payload: { reason: 'review test' },
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/admin/matches/match-review-1/review',
+      headers: { authorization: `Bearer ${VALID_TOKEN}` },
+      payload: { status: 'cleared', note: 'false positive' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body) as { status: string; flag: { reviewStatus: string } };
+    expect(body.status).toBe('ok');
+    expect(body.flag.reviewStatus).toBe('cleared');
+  });
+
+  it('POST /v1/admin/matches/:matchId/review returns 400 for invalid status', async () => {
+    await app.inject({
+      method: 'POST',
+      url: '/v1/admin/matches/match-review-2/flag',
+      headers: { authorization: `Bearer ${VALID_TOKEN}` },
+      payload: { reason: 'test' },
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/admin/matches/match-review-2/review',
+      headers: { authorization: `Bearer ${VALID_TOKEN}` },
+      payload: { status: 'invalid-status' },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/apps/gateway/test/unit/services/anti-cheat.test.ts
+++ b/apps/gateway/test/unit/services/anti-cheat.test.ts
@@ -128,6 +128,11 @@ describe('SelfPlayDetector', () => {
     expect(result.blocked).toBe(false);
   });
 
+  it('does not block when IP information is missing for both participants', () => {
+    const result = detector.checkEnqueue('uid-2', '', [{ uid: 'uid-1', ip: '' }]);
+    expect(result.blocked).toBe(false);
+  });
+
   it('blocks same uid', () => {
     const result = detector.checkEnqueue('uid-1', '5.6.7.8', [{ uid: 'uid-1', ip: '1.2.3.4' }]);
     expect(result.blocked).toBe(true);
@@ -249,6 +254,33 @@ describe('verifyEventChain', () => {
         hash: h1,
         actionData: 'TAMPERED-action-1',
         prevHash: h0,
+      },
+    ];
+
+    const result = verifyEventChain(events);
+    expect(result.valid).toBe(false);
+    expect(result.firstInvalidIndex).toBe(1);
+  });
+
+  it('detects broken prevHash linkage even if each hash is internally valid', () => {
+    const h0 = computeEventHash(
+      '0000000000000000000000000000000000000000000000000000000000000000',
+      'action-0',
+    );
+    const detachedPrevHash =
+      'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+    const h1 = computeEventHash(detachedPrevHash, 'action-1');
+
+    const events = [
+      {
+        hash: h0,
+        actionData: 'action-0',
+        prevHash: '0000000000000000000000000000000000000000000000000000000000000000',
+      },
+      {
+        hash: h1,
+        actionData: 'action-1',
+        prevHash: detachedPrevHash,
       },
     ];
 

--- a/apps/gateway/test/unit/services/anti-cheat.test.ts
+++ b/apps/gateway/test/unit/services/anti-cheat.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+
+import {
+  AnomalousSpeedDetector,
+  SelfPlayDetector,
+  computeEventHash,
+  verifyEventChain,
+} from '../../../src/services/anti-cheat.js';
+
+// ---------------------------------------------------------------------------
+// In-memory Redis mock
+// ---------------------------------------------------------------------------
+
+class MockRedis {
+  private readonly data = new Map<string, string>();
+
+  async get(key: string): Promise<string | null> {
+    return this.data.get(key) ?? null;
+  }
+
+  async set(key: string, value: string, ..._args: unknown[]): Promise<'OK'> {
+    this.data.set(key, value);
+    return 'OK';
+  }
+
+  async del(...keys: string[]): Promise<number> {
+    let count = 0;
+    for (const key of keys) {
+      if (this.data.delete(key)) count++;
+    }
+    return count;
+  }
+
+  async keys(pattern: string): Promise<string[]> {
+    const prefix = pattern.replace('*', '');
+    return [...this.data.keys()].filter((k) => k.startsWith(prefix));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// AnomalousSpeedDetector
+// ---------------------------------------------------------------------------
+
+describe('AnomalousSpeedDetector', () => {
+  let redis: MockRedis;
+  let detector: AnomalousSpeedDetector;
+
+  beforeEach(() => {
+    redis = new MockRedis();
+    detector = new AnomalousSpeedDetector(redis as never);
+  });
+
+  it('does not flag actions separated by more than the threshold', async () => {
+    const now = Date.now();
+
+    // Simulate 3 actions each 200ms apart — above 100ms threshold
+    await detector.checkAction('match-1', 'agent-1', 100, 3, now);
+    await detector.checkAction('match-1', 'agent-1', 100, 3, now + 200);
+    const result = await detector.checkAction('match-1', 'agent-1', 100, 3, now + 400);
+
+    expect(result.flagged).toBe(false);
+  });
+
+  it('flags after consecutiveCount rapid actions (all < thresholdMs)', async () => {
+    const now = Date.now();
+
+    // 3 actions each 50ms apart — all below 100ms threshold
+    await detector.checkAction('match-1', 'agent-1', 100, 3, now);
+    await detector.checkAction('match-1', 'agent-1', 100, 3, now + 50);
+    const result = await detector.checkAction('match-1', 'agent-1', 100, 3, now + 100);
+
+    expect(result.flagged).toBe(true);
+    expect(result.reason).toBeDefined();
+  });
+
+  it('does not flag when under consecutiveCount rapid actions', async () => {
+    const now = Date.now();
+
+    // Only 2 rapid actions — needs 3 to flag
+    await detector.checkAction('match-1', 'agent-1', 100, 3, now);
+    const result = await detector.checkAction('match-1', 'agent-1', 100, 3, now + 50);
+
+    expect(result.flagged).toBe(false);
+  });
+
+  it('resets detection after a slow action breaks the streak', async () => {
+    const now = Date.now();
+
+    // 2 rapid, then 1 slow, then 1 rapid — streak only reaches 2 after reset
+    await detector.checkAction('match-1', 'agent-1', 100, 3, now);
+    await detector.checkAction('match-1', 'agent-1', 100, 3, now + 50);
+    await detector.checkAction('match-1', 'agent-1', 100, 3, now + 300); // slow resets streak to 1
+    const result = await detector.checkAction('match-1', 'agent-1', 100, 3, now + 350); // streak=2
+
+    expect(result.flagged).toBe(false);
+  });
+
+  it('clearMatch removes stored timestamps', async () => {
+    const now = Date.now();
+
+    await detector.checkAction('match-1', 'agent-1', 100, 3, now);
+    await detector.clearMatch('match-1');
+
+    // After clearing, streak resets — can't reach 3 consecutive with only 1 new action
+    const result = await detector.checkAction('match-1', 'agent-1', 100, 3, now + 50);
+    expect(result.flagged).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SelfPlayDetector
+// ---------------------------------------------------------------------------
+
+describe('SelfPlayDetector', () => {
+  let detector: SelfPlayDetector;
+
+  beforeEach(() => {
+    detector = new SelfPlayDetector();
+  });
+
+  it('allows a new participant when no active participants', () => {
+    const result = detector.checkEnqueue('uid-1', '1.2.3.4', []);
+    expect(result.blocked).toBe(false);
+  });
+
+  it('allows different uid and different ip', () => {
+    const result = detector.checkEnqueue('uid-2', '5.6.7.8', [{ uid: 'uid-1', ip: '1.2.3.4' }]);
+    expect(result.blocked).toBe(false);
+  });
+
+  it('blocks same uid', () => {
+    const result = detector.checkEnqueue('uid-1', '5.6.7.8', [{ uid: 'uid-1', ip: '1.2.3.4' }]);
+    expect(result.blocked).toBe(true);
+    expect(result.reason).toMatch(/uid/i);
+  });
+
+  it('blocks same ip', () => {
+    const result = detector.checkEnqueue('uid-2', '1.2.3.4', [{ uid: 'uid-1', ip: '1.2.3.4' }]);
+    expect(result.blocked).toBe(true);
+    expect(result.reason).toMatch(/ip/i);
+  });
+
+  it('blocks when both uid and ip match', () => {
+    const result = detector.checkEnqueue('uid-1', '1.2.3.4', [{ uid: 'uid-1', ip: '1.2.3.4' }]);
+    expect(result.blocked).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeEventHash / verifyEventChain
+// ---------------------------------------------------------------------------
+
+describe('computeEventHash', () => {
+  it('returns a 64-character hex string (SHA-256)', () => {
+    const hash = computeEventHash('0000', 'action-data');
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('is deterministic', () => {
+    const h1 = computeEventHash('prev', 'data');
+    const h2 = computeEventHash('prev', 'data');
+    expect(h1).toBe(h2);
+  });
+
+  it('changes when prevHash changes', () => {
+    const h1 = computeEventHash('prev-a', 'data');
+    const h2 = computeEventHash('prev-b', 'data');
+    expect(h1).not.toBe(h2);
+  });
+
+  it('changes when actionData changes', () => {
+    const h1 = computeEventHash('prev', 'data-a');
+    const h2 = computeEventHash('prev', 'data-b');
+    expect(h1).not.toBe(h2);
+  });
+});
+
+describe('verifyEventChain', () => {
+  it('returns valid=true for an empty chain', () => {
+    expect(verifyEventChain([])).toEqual({ valid: true });
+  });
+
+  it('returns valid=true for a correctly hashed chain', () => {
+    const h0 = computeEventHash(
+      '0000000000000000000000000000000000000000000000000000000000000000',
+      'action-0',
+    );
+    const h1 = computeEventHash(h0, 'action-1');
+    const h2 = computeEventHash(h1, 'action-2');
+
+    const events = [
+      {
+        hash: h0,
+        actionData: 'action-0',
+        prevHash: '0000000000000000000000000000000000000000000000000000000000000000',
+      },
+      { hash: h1, actionData: 'action-1', prevHash: h0 },
+      { hash: h2, actionData: 'action-2', prevHash: h1 },
+    ];
+
+    expect(verifyEventChain(events)).toEqual({ valid: true });
+  });
+
+  it('returns valid=false with firstInvalidIndex when a hash is tampered', () => {
+    const h0 = computeEventHash(
+      '0000000000000000000000000000000000000000000000000000000000000000',
+      'action-0',
+    );
+    const h1 = computeEventHash(h0, 'action-1');
+
+    const events = [
+      {
+        hash: h0,
+        actionData: 'action-0',
+        prevHash: '0000000000000000000000000000000000000000000000000000000000000000',
+      },
+      {
+        hash: 'tampered-hash',
+        actionData: 'action-1',
+        prevHash: h0,
+      },
+      {
+        hash: computeEventHash('tampered-hash', 'action-2'),
+        actionData: 'action-2',
+        prevHash: 'tampered-hash',
+      },
+    ];
+
+    const result = verifyEventChain(events);
+    expect(result.valid).toBe(false);
+    expect(result.firstInvalidIndex).toBe(1);
+  });
+
+  it('detects tampered actionData', () => {
+    const h0 = computeEventHash(
+      '0000000000000000000000000000000000000000000000000000000000000000',
+      'action-0',
+    );
+    const h1 = computeEventHash(h0, 'action-1');
+
+    const events = [
+      {
+        hash: h0,
+        actionData: 'action-0',
+        prevHash: '0000000000000000000000000000000000000000000000000000000000000000',
+      },
+      {
+        // Hash was computed correctly but actionData was changed after the fact
+        hash: h1,
+        actionData: 'TAMPERED-action-1',
+        prevHash: h0,
+      },
+    ];
+
+    const result = verifyEventChain(events);
+    expect(result.valid).toBe(false);
+    expect(result.firstInvalidIndex).toBe(1);
+  });
+});

--- a/apps/gateway/test/unit/services/anti-cheat.test.ts
+++ b/apps/gateway/test/unit/services/anti-cheat.test.ts
@@ -267,8 +267,7 @@ describe('verifyEventChain', () => {
       '0000000000000000000000000000000000000000000000000000000000000000',
       'action-0',
     );
-    const detachedPrevHash =
-      'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+    const detachedPrevHash = 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
     const h1 = computeEventHash(detachedPrevHash, 'action-1');
 
     const events = [


### PR DESCRIPTION
## Summary
- Add `AnomalousSpeedDetector`: flags agents submitting actions < 100ms apart (3 consecutive), using Redis-backed streak counter with automatic reset on slow actions
- Add `SelfPlayDetector`: blocks same-UID or same-IP from joining both sides of a match (stateless, caller-supplied participant list)
- Add `ReplayIntegrityChecker`: SHA-256 hash chain verification (`computeEventHash` + `verifyEventChain`) for replay tamper detection using Node.js built-in `crypto`
- Add admin REST endpoints for flagging and reviewing suspicious matches with 30-day TTL in Redis
- All admin routes protected by `INTERNAL_TASK_AUTH_TOKEN` via timing-safe comparison

Implements PR-24 from PLAN.md. Dependency: PR-07 ✅

## Test plan
- [ ] `pnpm --filter @moltgames/gateway test:unit` passes (142 tests: 18 anti-cheat + 10 admin + 114 pre-existing)
- [ ] `pnpm typecheck` passes with no errors
- [ ] `pnpm lint` passes
- [ ] `pnpm build` succeeds
- [ ] Admin endpoints return 401 without correct token
- [ ] Admin endpoints return 401 with wrong token
- [ ] `POST /v1/admin/matches/:matchId/flag` stores flag and returns 200
- [ ] `GET /v1/admin/matches/flagged` lists all flagged matches
- [ ] `POST /v1/admin/matches/:matchId/review` updates flag status
- [ ] AnomalousSpeedDetector correctly identifies rapid actions and resets streak on slow actions
- [ ] verifyEventChain detects tampered hashes and tampered actionData
- [ ] SelfPlayDetector blocks same-uid and same-ip participants

🤖 Generated with [Claude Code](https://claude.com/claude-code)