### PR TITLE
[PR-20c] Harden runner trace masking for bench logs

### DIFF
--- a/test/e2e/agent-battle-bench.test.ts
+++ b/test/e2e/agent-battle-bench.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { describe, expect, it } from 'vitest';
 import WebSocket from 'ws';
 import { requestJsonWithRetry } from '../../tools/agent-runner/src/http/request-json.js';
+import { summarizeAndSanitizeTraceValue } from '../../tools/agent-runner/src/logging/trace-logger.js';
 
 const GATEWAY_URL = process.env.GATEWAY_URL || 'http://localhost:8080';
 const GATEWAY_WS_URL = process.env.GATEWAY_WS_URL || 'ws://localhost:8080/v1/ws';
@@ -316,60 +317,6 @@ const waitForMessage = async (
   return found;
 };
 
-const truncateText = (value: string, maxLength = 180): string => {
-  if (value.length <= maxLength) {
-    return value;
-  }
-
-  return `${value.slice(0, maxLength)}...`;
-};
-
-const summarizeValue = (value: unknown, depth = 0): unknown => {
-  if (value === null || value === undefined) {
-    return value;
-  }
-
-  if (typeof value === 'string') {
-    return truncateText(value);
-  }
-
-  if (typeof value === 'number' || typeof value === 'boolean') {
-    return value;
-  }
-
-  if (depth >= 2) {
-    if (Array.isArray(value)) {
-      return `[array:${value.length}]`;
-    }
-    if (isRecord(value)) {
-      return '[object]';
-    }
-    return String(value);
-  }
-
-  if (Array.isArray(value)) {
-    const summarized = value.slice(0, 4).map((item) => summarizeValue(item, depth + 1));
-    if (value.length > 4) {
-      summarized.push(`...(${value.length - 4} more)`);
-    }
-    return summarized;
-  }
-
-  if (isRecord(value)) {
-    const entries = Object.entries(value).slice(0, 8);
-    const next: Record<string, unknown> = {};
-    for (const [key, val] of entries) {
-      next[key] = summarizeValue(val, depth + 1);
-    }
-    if (Object.keys(value).length > 8) {
-      next.__truncated_keys__ = Object.keys(value).length - 8;
-    }
-    return next;
-  }
-
-  return String(value);
-};
-
 const recordAction = (
   timeline: ActionTrace[],
   params: {
@@ -394,8 +341,8 @@ const recordAction = (
     decisionSource: params.decisionSource,
     availableTools: [...params.availableTools],
     tool: params.tool,
-    argsSummary: summarizeValue(params.args),
-    responseSummary: summarizeValue(params.response),
+    argsSummary: summarizeAndSanitizeTraceValue(params.args),
+    responseSummary: summarizeAndSanitizeTraceValue(params.response),
     decisionDurationMs: params.decisionDurationMs,
     actionDurationMs: params.actionDurationMs,
   });

--- a/tools/agent-runner/src/logging/trace-logger.ts
+++ b/tools/agent-runner/src/logging/trace-logger.ts
@@ -1,10 +1,14 @@
-const API_KEY_PATTERN = /\b(?:sk-[\w-]+|AIza[\w-]+)\b/;
-const API_KEY_TEXT_PATTERN = /\b(?:sk-[\w-]+|AIza[\w-]+)\b/g;
-const EMAIL_PATTERN = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i;
-const EMAIL_TEXT_PATTERN = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
-const PHONE_PATTERN = /(?:\+?\d[\d()\s-]{7,}\d)/;
-const PHONE_TEXT_PATTERN = /(?:\+?\d[\d()\s-]{7,}\d)/g;
-const SECRET_TEXT_PATTERN = /\bSECRET-[\w-]+\b/g;
+const API_KEY_PATTERN_SOURCE = String.raw`\b(?:sk-[\w-]+|AIza[\w-]+)\b`;
+const EMAIL_PATTERN_SOURCE = String.raw`\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b`;
+const PHONE_PATTERN_SOURCE = String.raw`(?:\+?\d[\d()\s-]{7,}\d)`;
+const SECRET_PATTERN_SOURCE = String.raw`\bSECRET-[\w-]+\b`;
+
+const createPattern = (source: string, flags = ''): RegExp => new RegExp(source, flags);
+
+const API_KEY_TEXT_PATTERN = createPattern(API_KEY_PATTERN_SOURCE, 'g');
+const EMAIL_TEXT_PATTERN = createPattern(EMAIL_PATTERN_SOURCE, 'gi');
+const PHONE_TEXT_PATTERN = createPattern(PHONE_PATTERN_SOURCE, 'g');
+const SECRET_TEXT_PATTERN = createPattern(SECRET_PATTERN_SOURCE, 'g');
 
 const TOKEN_KEY_PATTERN = /(?:authorization|token)/i;
 const API_KEY_KEY_PATTERN = /api[_-]?key/i;
@@ -61,19 +65,7 @@ const sanitizeString = (value: string, keyName?: string): string => {
   sanitized = sanitized.replace(EMAIL_TEXT_PATTERN, '[REDACTED_TEXT]');
   sanitized = sanitized.replace(PHONE_TEXT_PATTERN, '[REDACTED_TEXT]');
 
-  if (sanitized !== value) {
-    return sanitized;
-  }
-
-  if (API_KEY_PATTERN.test(value)) {
-    return keyName && API_KEY_KEY_PATTERN.test(keyName) ? '[REDACTED_API_KEY]' : '[REDACTED_TEXT]';
-  }
-
-  if (EMAIL_PATTERN.test(value) || PHONE_PATTERN.test(value)) {
-    return '[REDACTED_TEXT]';
-  }
-
-  return value;
+  return sanitized;
 };
 
 export const sanitizeTraceValue = (value: unknown, keyName?: string): unknown => {
@@ -97,7 +89,7 @@ export const sanitizeTraceValue = (value: unknown, keyName?: string): unknown =>
   return value;
 };
 
-export const summarizeTraceValue = (value: unknown, depth = 0): unknown => {
+const summarizeTraceValue = (value: unknown, depth = 0): unknown => {
   if (value === null || value === undefined) {
     return value;
   }
@@ -137,7 +129,7 @@ export const summarizeTraceValue = (value: unknown, depth = 0): unknown => {
       next[entryKey] = summarizeTraceValue(entryValue, depth + 1);
     }
     if (Object.keys(value).length > 8) {
-      next.__truncated_keys__ = Object.keys(value).length - 8;
+      next._truncatedKeys = Object.keys(value).length - 8;
     }
     return next;
   }

--- a/tools/agent-runner/src/logging/trace-logger.ts
+++ b/tools/agent-runner/src/logging/trace-logger.ts
@@ -1,11 +1,18 @@
 const API_KEY_PATTERN = /\b(?:sk-[\w-]+|AIza[\w-]+)\b/;
+const API_KEY_TEXT_PATTERN = /\b(?:sk-[\w-]+|AIza[\w-]+)\b/g;
 const EMAIL_PATTERN = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i;
+const EMAIL_TEXT_PATTERN = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
 const PHONE_PATTERN = /(?:\+?\d[\d()\s-]{7,}\d)/;
+const PHONE_TEXT_PATTERN = /(?:\+?\d[\d()\s-]{7,}\d)/g;
+const SECRET_TEXT_PATTERN = /\bSECRET-[\w-]+\b/g;
 
 const TOKEN_KEY_PATTERN = /(?:authorization|token)/i;
 const API_KEY_KEY_PATTERN = /api[_-]?key/i;
 const SECRET_KEY_PATTERN = /(?:secret|guess)/i;
 const REASONING_KEY_PATTERN = /(?:reasoning|thought|chain[_-]?of[_-]?thought|cot)/i;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
 
 export interface TraceLogEntry {
   event: string;
@@ -48,6 +55,16 @@ const sanitizeString = (value: string, keyName?: string): string => {
     return '[REDACTED_SECRET]';
   }
 
+  let sanitized = value;
+  sanitized = sanitized.replace(API_KEY_TEXT_PATTERN, '[REDACTED_API_KEY]');
+  sanitized = sanitized.replace(SECRET_TEXT_PATTERN, '[REDACTED_SECRET]');
+  sanitized = sanitized.replace(EMAIL_TEXT_PATTERN, '[REDACTED_TEXT]');
+  sanitized = sanitized.replace(PHONE_TEXT_PATTERN, '[REDACTED_TEXT]');
+
+  if (sanitized !== value) {
+    return sanitized;
+  }
+
   if (API_KEY_PATTERN.test(value)) {
     return keyName && API_KEY_KEY_PATTERN.test(keyName) ? '[REDACTED_API_KEY]' : '[REDACTED_TEXT]';
   }
@@ -79,6 +96,57 @@ export const sanitizeTraceValue = (value: unknown, keyName?: string): unknown =>
 
   return value;
 };
+
+export const summarizeTraceValue = (value: unknown, depth = 0): unknown => {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    return value.length <= 180 ? value : `${value.slice(0, 180)}...`;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+
+  if (depth >= 2) {
+    if (Array.isArray(value)) {
+      return `[array:${value.length}]`;
+    }
+
+    if (isRecord(value)) {
+      return '[object]';
+    }
+
+    return String(value);
+  }
+
+  if (Array.isArray(value)) {
+    const summarized = value.slice(0, 4).map((item) => summarizeTraceValue(item, depth + 1));
+    if (value.length > 4) {
+      summarized.push(`...(${value.length - 4} more)`);
+    }
+    return summarized;
+  }
+
+  if (isRecord(value)) {
+    const entries = Object.entries(value).slice(0, 8);
+    const next: Record<string, unknown> = {};
+    for (const [entryKey, entryValue] of entries) {
+      next[entryKey] = summarizeTraceValue(entryValue, depth + 1);
+    }
+    if (Object.keys(value).length > 8) {
+      next.__truncated_keys__ = Object.keys(value).length - 8;
+    }
+    return next;
+  }
+
+  return String(value);
+};
+
+export const summarizeAndSanitizeTraceValue = (value: unknown): unknown =>
+  sanitizeTraceValue(summarizeTraceValue(value));
 
 export class ConsoleJsonTraceLogger implements TraceLogger {
   constructor(private readonly options: ConsoleJsonTraceLoggerOptions = {}) {}

--- a/tools/agent-runner/test/unit/logging/trace-logger.test.ts
+++ b/tools/agent-runner/test/unit/logging/trace-logger.test.ts
@@ -67,6 +67,39 @@ describe('summarizeAndSanitizeTraceValue', () => {
       },
     });
   });
+
+  it('sanitizes api keys that remain after long-string truncation', () => {
+    const longPrefix = 'x'.repeat(160);
+    const result = summarizeAndSanitizeTraceValue(`${longPrefix} sk-test-key-abc`);
+
+    expect(result).toEqual(`${longPrefix} [REDACTED_API_KEY]`);
+  });
+
+  it('uses _truncatedKeys metadata when summarizing large objects', () => {
+    expect(
+      summarizeAndSanitizeTraceValue({
+        first: 1,
+        second: 2,
+        third: 3,
+        fourth: 4,
+        fifth: 5,
+        sixth: 6,
+        seventh: 7,
+        eighth: 8,
+        ninth: 9,
+      }),
+    ).toEqual({
+      first: 1,
+      second: 2,
+      third: 3,
+      fourth: 4,
+      fifth: 5,
+      sixth: 6,
+      seventh: 7,
+      eighth: 8,
+      _truncatedKeys: 1,
+    });
+  });
 });
 
 describe('ConsoleJsonTraceLogger', () => {

--- a/tools/agent-runner/test/unit/logging/trace-logger.test.ts
+++ b/tools/agent-runner/test/unit/logging/trace-logger.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { ConsoleJsonTraceLogger, sanitizeTraceValue } from '../../../src/logging/trace-logger.js';
+import {
+  ConsoleJsonTraceLogger,
+  sanitizeTraceValue,
+  summarizeAndSanitizeTraceValue,
+} from '../../../src/logging/trace-logger.js';
 
 describe('sanitizeTraceValue', () => {
   it('masks tokens, api keys, secrets, and reasoning-like fields', () => {
@@ -29,7 +33,39 @@ describe('sanitizeTraceValue', () => {
   it('masks email addresses and phone numbers embedded in strings', () => {
     expect(
       sanitizeTraceValue('contact test@example.com or +1 (555) 123-4567 with sk-test-secret'),
-    ).toBe('[REDACTED_TEXT]');
+    ).toBe('contact [REDACTED_TEXT] or [REDACTED_TEXT] with [REDACTED_API_KEY]');
+  });
+
+  it('redacts embedded secrets and api keys inside free-form text', () => {
+    expect(
+      sanitizeTraceValue({
+        content: 'Use SECRET-apple-0 with sk-test-123456 and email test@example.com',
+        note: 'Previous guess SECRET-banana-1 was rejected.',
+      }),
+    ).toEqual({
+      content: 'Use [REDACTED_SECRET] with [REDACTED_API_KEY] and email [REDACTED_TEXT]',
+      note: 'Previous guess [REDACTED_SECRET] was rejected.',
+    });
+  });
+});
+
+describe('summarizeAndSanitizeTraceValue', () => {
+  it('preserves compact summaries while masking bench-style secret guesses', () => {
+    expect(
+      summarizeAndSanitizeTraceValue({
+        guess: 'SECRET-benchmark-probe-42',
+        result: {
+          accepted: true,
+          echoed: 'SECRET-benchmark-probe-42',
+        },
+      }),
+    ).toEqual({
+      guess: '[REDACTED_SECRET]',
+      result: {
+        accepted: true,
+        echoed: '[REDACTED_SECRET]',
+      },
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- harden `tools/agent-runner` trace sanitization to redact embedded secrets, emails, phone numbers, and API keys inside free-form text
- add shared summary+sanitization helpers and route agent battle bench action timelines through them
- add unit coverage for embedded-value redaction and bench-style secret guess masking

## Exit Criteria Status
- [ ] LLM エージェント 2 体で Prompt Injection Arena を連続 10 試合以上実行できる
- [ ] 再接続シナリオを含む E2E がローカルで安定して再現できる
- [ ] 外部 API 依存なしのモック E2E が CI で常時グリーン
- [~] セキュリティ要件 (ログマスク、秘密値非保存) をテストで担保
  - runner trace logger と agent bench timeline のマスク経路を追加・検証

## Tests
- `pnpm --filter @moltgames/agent-runner test:unit -- test/unit/logging/trace-logger.test.ts`
- `pnpm --filter @moltgames/agent-runner lint`
- `pnpm --filter @moltgames/agent-runner typecheck`
- `pnpm exec eslint test/e2e/agent-battle-bench.test.ts`
- `pnpm exec vitest run test/e2e/agent-battle-bench.test.ts` (bench tests skipped without `RUN_AGENT_BENCH` / `RUN_LLM_BENCH`)

## Notes
- Full local E2E suites that hit gateway/engine were not run here because the required services were not started in this session.
- `docs/PLAN.md` was left unchanged because this PR only closes part of PR-20c's remaining security coverage work.
